### PR TITLE
Fix markdown converter bug

### DIFF
--- a/src/utils/markdown-converter.ts
+++ b/src/utils/markdown-converter.ts
@@ -2,5 +2,5 @@ import md2sb from 'md2sb';
 
 export async function convertMarkdownToScrapbox(markdown: string): Promise<string> {
   // md2sbを直接呼び出し、エラーは上位に伝播させる
-  return await md2sb.default(markdown);
+  return await md2sb(markdown);
 }


### PR DESCRIPTION
## Summary
- fix call to `md2sb` in markdown conversion utility

## Testing
- `npm run build` *(fails: Cannot find module '@whatwg-node/fetch' or its corresponding type declarations)*