### PR TITLE
fix: manifest.json のバージョンを v0.6.0 に更新

### DIFF
--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -70,7 +70,13 @@ jobs:
           echo "エラー: タグ v${TAG_VERSION} と package.json ${PKG_VERSION} のバージョンが一致しません"
           exit 1
         fi
-        echo "バージョン一致: ${PKG_VERSION}"
+        echo "タグとpackage.jsonのバージョン一致: ${PKG_VERSION}"
+        MANIFEST_VERSION=$(node -p "require('./manifest.json').version")
+        if [ "$PKG_VERSION" != "$MANIFEST_VERSION" ]; then
+          echo "エラー: package.json (${PKG_VERSION}) と manifest.json (${MANIFEST_VERSION}) のバージョンが一致しません"
+          exit 1
+        fi
+        echo "manifest.jsonのバージョンも一致: ${MANIFEST_VERSION}"
 
     - name: npm に公開
       run: npm publish --provenance

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "scrapbox-cosense-mcp",
-  "version": "0.5.0",
+  "version": "0.6.0",
   "description": "MCP server for Cosense/Scrapbox - Read, search, create and edit pages",
   "author": {
     "name": "worldnine"


### PR DESCRIPTION
## Summary
- `manifest.json` のバージョンが v0.5.0 のまま `package.json` (v0.6.0) と不整合だったため修正
- `publish-npm.yml` に package.json ↔ manifest.json のバージョン一致チェックを追加し再発を防止

## Test plan
- [x] `npm run test` — 175/175 パス
- [x] `npm run lint` — 0 エラー
- [x] `manifest.json` と `package.json` のバージョンが一致していることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)