### PR TITLE
release: v0.7.0

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "scrapbox-cosense-mcp",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "MCP server for Cosense/Scrapbox - Read, search, create and edit pages",
   "author": {
     "name": "worldnine"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrapbox-cosense-mcp",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrapbox-cosense-mcp",
-      "version": "0.6.1",
+      "version": "0.7.0",
       "license": "MIT",
       "dependencies": {
         "@cosense/std": "npm:@jsr/cosense__std@^0.29.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrapbox-cosense-mcp",
-  "version": "0.6.1",
+  "version": "0.7.0",
   "description": "MCP server for cosense",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## Summary

- v0.7.0 リリース準備
- `get_smart_context` ツール追加（Smart Context API による関連ページ一括取得）

## Changes in v0.7.0

- `get_smart_context` MCP ツール + CLI `context` コマンド追加
- 1ホップ / 2ホップのリンク先ページをAI向けフォーマットで一括取得
- compact モードでヘッダー除去
- hopCount バリデーション（1/2 のみ許可）
- E2E テスト追加（CLI + MCP）

🤖 Generated with [Claude Code](https://claude.com/claude-code)