### PR TITLE
fix: Auto Release のバッククォート問題と npm publish 未トリガー問題を修正

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,7 +1,9 @@
 name: Auto Release
 
 # release/v* ブランチのPRがmainにマージされたら、タグとGitHub Releaseを自動作成
-# 既存の publish-npm.yml（タグ発火）と release-mcpb.yml（リリース発火）が後続処理を行う
+# GITHUB_TOKEN による push は別ワークフローをトリガーしないため、
+# publish-npm は workflow_dispatch で明示的にトリガーする
+# release-mcpb は GitHub Release の published イベントで自動トリガーされる
 
 on:
   pull_request:
@@ -17,6 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+      actions: write
 
     steps:
     - name: コードをチェックアウト
@@ -42,10 +45,18 @@ jobs:
 
     - name: GitHub Release を作成
       if: env.SKIP != 'true'
+      env:
+        PR_BODY: ${{ github.event.pull_request.body }}
+        GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
-        PR_BODY="${{ github.event.pull_request.body }}"
         gh release create "${TAG}" \
           --title "${TAG}" \
           --notes "${PR_BODY:-リリース ${TAG}}"
+
+    - name: npm publish ワークフローをトリガー
+      if: env.SKIP != 'true'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      run: |
+        gh workflow run "Publish to npm" --ref "${TAG}"
+        echo "Publish to npm ワークフローをトリガーしました"

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -4,6 +4,7 @@ on:
   push:
     tags:
       - 'v*'
+  workflow_dispatch:
 
 jobs:
   quality-check:


### PR DESCRIPTION
## Summary

- PR body のバッククォートがシェルコマンド置換として解釈される問題を修正（env 経由で渡すように変更）
- GITHUB_TOKEN による tag push が別ワークフローをトリガーしない問題を修正（workflow_dispatch で明示的にトリガー）

## 背景

v0.7.0 リリース時に Auto Release が失敗し、npm publish と .mcpb ビルドを手動で実行する必要があった。

## Test plan

- [ ] release/v* ブランチのPRマージ時に Auto Release が成功すること
- [ ] GitHub Release が正常に作成されること
- [ ] publish-npm が自動トリガーされること
- [ ] release-mcpb が自動トリガーされること

🤖 Generated with [Claude Code](https://claude.com/claude-code)