### PR TITLE
fix: release-mcpb も workflow_dispatch で明示的にトリガーする

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -1,9 +1,8 @@
 name: Auto Release
 
 # release/v* ブランチのPRがmainにマージされたら、タグとGitHub Releaseを自動作成
-# GITHUB_TOKEN による push は別ワークフローをトリガーしないため、
-# publish-npm は workflow_dispatch で明示的にトリガーする
-# release-mcpb は GitHub Release の published イベントで自動トリガーされる
+# GITHUB_TOKEN によるイベントは別ワークフローをトリガーしないため、
+# publish-npm と release-mcpb は workflow_dispatch で明示的にトリガーする
 
 on:
   pull_request:
@@ -53,10 +52,12 @@ jobs:
           --title "${TAG}" \
           --notes "${PR_BODY:-リリース ${TAG}}"
 
-    - name: npm publish ワークフローをトリガー
+    - name: 後続ワークフローをトリガー
       if: env.SKIP != 'true'
       env:
         GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       run: |
         gh workflow run "Publish to npm" --ref "${TAG}"
-        echo "Publish to npm ワークフローをトリガーしました"
+        echo "Publish to npm をトリガーしました"
+        gh workflow run "Release MCPB" --ref "${TAG}"
+        echo "Release MCPB をトリガーしました"

--- a/.github/workflows/release-mcpb.yml
+++ b/.github/workflows/release-mcpb.yml
@@ -3,6 +3,7 @@ name: Release MCPB
 on:
   release:
     types: [published]
+  workflow_dispatch:
 
 permissions:
   contents: write


### PR DESCRIPTION
## Summary

- GITHUB_TOKEN で作成した GitHub Release も別ワークフローをトリガーしない
- release-mcpb.yml に workflow_dispatch を追加
- auto-release.yml から publish-npm と release-mcpb の両方を明示的にトリガー

## 背景

v0.7.1 リリースで Auto Release は成功したが .mcpb が添付されなかった。
publish-npm と同じ GITHUB_TOKEN の制約が原因。

🤖 Generated with [Claude Code](https://claude.com/claude-code)