### PR TITLE
fix: marketplace sourceをnpmに変更

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -9,7 +9,10 @@
   "plugins": [
     {
       "name": "scrapbox-cosense",
-      "source": "./",
+      "source": {
+        "source": "npm",
+        "package": "scrapbox-cosense-mcp"
+      },
       "description": "Scrapbox/Cosense integration - read, search, create, and edit wiki pages"
     }
   ]


### PR DESCRIPTION
## Summary
- marketplace.jsonの`source`を`"./"`からnpmパッケージ参照に変更
- `plugin install`時に`build/`と`node_modules/`が欠落し、MCPサーバー・CLIが動作しない問題を修正
- npmソースにすることで`npm install`時に`prepare`スクリプト経由で自動ビルドされる

## 原因
`source: "./"` はGitHubからcloneされたファイルをそのままコピーするが、`.gitignore`対象の`build/`と`node_modules/`は含まれないため、エントリポイント(`build/index.js`)が存在しなかった。

## Test plan
- [ ] `plugin uninstall` → `plugin install` で再インストール
- [ ] キャッシュディレクトリに `build/` と `node_modules/` が存在することを確認
- [ ] MCPサーバーとしての起動確認
- [ ] CLIコマンド（`get`, `search`等）の動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)