### PR TITLE
fix: リリースやり直し時のワークフロー失敗を修正

### DIFF
--- a/.github/workflows/auto-release.yml
+++ b/.github/workflows/auto-release.yml
@@ -31,9 +31,9 @@ jobs:
         echo "VERSION=${VERSION}" >> "$GITHUB_ENV"
         echo "TAG=${TAG}" >> "$GITHUB_ENV"
 
-        # タグが既に存在する場合はスキップ
-        if git rev-parse "${TAG}" >/dev/null 2>&1; then
-          echo "タグ ${TAG} は既に存在します。スキップします。"
+        # タグが既に存在する場合はスキップ（リモートも確認）
+        if git ls-remote --tags origin "refs/tags/${TAG}" | grep -q "${TAG}"; then
+          echo "タグ ${TAG} はリモートに既に存在します。スキップします。"
           echo "SKIP=true" >> "$GITHUB_ENV"
           exit 0
         fi

--- a/.github/workflows/publish-npm.yml
+++ b/.github/workflows/publish-npm.yml
@@ -79,7 +79,20 @@ jobs:
         fi
         echo "manifest.jsonのバージョンも一致: ${MANIFEST_VERSION}"
 
+    - name: npm に公開済みか確認
+      id: check-npm
+      run: |
+        PKG_VERSION=$(node -p "require('./package.json').version")
+        PKG_NAME=$(node -p "require('./package.json').name")
+        if npm view "${PKG_NAME}@${PKG_VERSION}" version 2>/dev/null; then
+          echo "バージョン ${PKG_VERSION} は既に npm に公開済みです。スキップします。"
+          echo "already_published=true" >> "$GITHUB_OUTPUT"
+        else
+          echo "already_published=false" >> "$GITHUB_OUTPUT"
+        fi
+
     - name: npm に公開
+      if: steps.check-npm.outputs.already_published != 'true'
       run: npm publish --provenance
       env:
         NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- auto-release.yml: タグ存在チェックを `git rev-parse`（ローカルのみ）から `git ls-remote`（リモート確認）に変更
- publish-npm.yml: `npm publish` 前に `npm view` で既公開チェックを追加し、公開済みならスキップ

## Why
リリースをやり直す際（GitHub Release削除→再作成）に、リモートにタグが残っていてpush失敗、npmに既公開でpublish失敗する問題があった。

## Test plan
- [ ] CI パス
- [ ] 次回リリース時に正常動作を確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)