### PR TITLE
fix: npmパッケージにmanifest.jsonを含める

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,8 @@
     "scrapbox-cosense-mcp": "./build/index.js"
   },
   "files": [
-    "build"
+    "build",
+    "manifest.json"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node -e \"require('fs').chmodSync('build/index.js', '755')\"",


### PR DESCRIPTION
## Summary
- `package.json`の`files`フィールドに`manifest.json`を追加
- プラグインとしてnpm経由でインストールした際に`manifest.json`が欠落し、`user_config`（プロジェクト名・SID）の設定フォームが表示されない問題を修正

## Test plan
- [ ] `npm pack --dry-run` で `manifest.json` が含まれることを確認済み
- [ ] lint 0エラー、テスト全パス確認済み
- [ ] プラグイン再インストール時に設定フォームが表示されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)