### PR TITLE
chore: v0.8.0 リリース（edit_lines ツール追加）

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "scrapbox-cosense-mcp",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "MCP server for Cosense/Scrapbox - Read, search, create and edit pages",
   "author": {
     "name": "worldnine"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrapbox-cosense-mcp",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrapbox-cosense-mcp",
-      "version": "0.7.3",
+      "version": "0.8.0",
       "license": "MIT",
       "dependencies": {
         "@cosense/std": "npm:@jsr/cosense__std@^0.29.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrapbox-cosense-mcp",
-  "version": "0.7.3",
+  "version": "0.8.0",
   "description": "MCP server for cosense",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## v0.8.0

### 新機能

- **`edit_lines` ツールを追加** — contributed by [@qurihara](https://github.com/qurihara) さん（#51, #52）🎉
  - ページ内の行を完全一致で探して新しい内容（複数行可）に置換します
  - 既定では最初の1件のみ置換。`matchAll: true` で全件置換
  - 一致する行が無い場合はエラーを返し、ページは変更しません（`insert_lines` の「末尾追記」との非対称は意図的な設計です。詳細は README を参照）
  - `format` パラメータで Markdown / Scrapbox 記法の両方に対応
  - CLI にも `edit` サブコマンドを追加（`scrapbox-cosense-mcp edit <title> --target=TEXT --text=TEXT [--all]`）

`edit_lines` は Issue #51 で栗原さん（@qurihara）からご提案・ご実装いただいたものです。既存コードのスタイルを丁寧に踏襲した、そのまま取り込める品質の PR をありがとうございました。同 Issue で提案されている `delete_page` は、安全策（環境変数によるオプトイン・存在チェック・ドライラン）を加えた上で次のリリースで追加予定です。

### Changes

- `package.json` / `manifest.json` のバージョンを 0.8.0 に更新

### Test plan

- [x] テスト 220/220 パス
- [x] ビルド成功
- [x] lint エラー 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dc27SQDzptfb6ZVM3xrr3Y
