### PR TITLE
fix: Claude Code プラグインの構成ファイルをnpmパッケージに同梱

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "scrapbox-cosense",
   "description": "Scrapbox/Cosense integration - read, search, create, and edit wiki pages",
-  "version": "0.5.0",
+  "version": "0.8.1",
   "author": {
     "name": "worldnine"
   },

--- a/.mcp.json
+++ b/.mcp.json
@@ -4,8 +4,8 @@
       "command": "npx",
       "args": ["-y", "scrapbox-cosense-mcp"],
       "env": {
-        "COSENSE_PROJECT_NAME": "",
-        "COSENSE_SID": ""
+        "COSENSE_PROJECT_NAME": "${COSENSE_PROJECT_NAME:-}",
+        "COSENSE_SID": "${COSENSE_SID:-}"
       }
     }
   }

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -39,6 +39,10 @@ All tools are also available as CLI subcommands (`get`, `list`, `search`, `creat
 
 `skills/scrapbox/SKILL.md` defines a Claude Code skill that wraps the CLI. When users invoke `/cosense`, Claude Code reads SKILL.md and executes CLI commands via Bash. Keep SKILL.md concise — details should be discoverable via `--help`.
 
+### Claude Code Plugin
+
+`.claude-plugin/` (plugin.json + marketplace.json) enables installation via `/plugin marketplace add worldnine/scrapbox-cosense-mcp`. The marketplace resolves the plugin from the **npm package**, so `.claude-plugin/`, `.mcp.json`, and `skills/` must be listed in package.json `files` — a plugin fix only takes effect after the next npm release.
+
 ### Desktop Extensions (.mcpb)
 
 `manifest.json` + `.mcpbignore` enable Claude Desktop Extensions packaging. The `.mcpb` file is auto-built and attached to GitHub Releases by `release-mcpb.yml`. To build locally: `npm install --omit=dev && npx @anthropic-ai/mcpb pack`.
@@ -85,7 +89,7 @@ See README.md. Key variables:
 
 ### Release Process
 
-1. Create `release/vX.Y.Z` branch, bump version in `package.json` + `manifest.json`
+1. Create `release/vX.Y.Z` branch, bump version in `package.json` + `manifest.json` + `.claude-plugin/plugin.json`
 2. Create PR → CI passes → merge
 3. Everything after merge is automatic (tag → npm → GitHub Release → .mcpb)
 

--- a/package.json
+++ b/package.json
@@ -14,7 +14,10 @@
   },
   "files": [
     "build",
-    "manifest.json"
+    "manifest.json",
+    ".claude-plugin",
+    ".mcp.json",
+    "skills"
   ],
   "scripts": {
     "build": "tsc -p tsconfig.build.json && node -e \"require('fs').chmodSync('build/index.js', '755')\"",

--- a/skills/scrapbox/SKILL.md
+++ b/skills/scrapbox/SKILL.md
@@ -1,7 +1,7 @@
 ---
 name: cosense
 description: Interact with Cosense (Scrapbox) pages - read, search, list, create, and edit pages. Use when the user mentions Cosense, Scrapbox, or wants to work with wiki pages.
-allowed-tools: Bash(scrapbox-cosense-mcp *)
+allowed-tools: Bash(npx -y scrapbox-cosense-mcp *), Bash(scrapbox-cosense-mcp *)
 argument-hint: <operation or natural language request>
 ---
 
@@ -11,16 +11,18 @@ Cosense ページの取得・検索・作成・編集。CLI 経由で実行。
 
 ## コマンド
 
-- `scrapbox-cosense-mcp get <title>` — ページ取得
-- `scrapbox-cosense-mcp search <query>` — キーワード検索
-- `scrapbox-cosense-mcp list [--sort=X --limit=N]` — ページ一覧
-- `scrapbox-cosense-mcp create <title> [--body=TEXT]` — ページ作成（markdown自動変換）
-- `scrapbox-cosense-mcp insert <title> --after=TEXT --text=TEXT` — 行挿入
-- `scrapbox-cosense-mcp edit <title> --target=TEXT --text=TEXT [--all]` — 行置換（完全一致、既定は最初の1件のみ）
-- `scrapbox-cosense-mcp url <title>` — URL生成
-- `scrapbox-cosense-mcp context <title> [--hop=1|2]` — 関連ページ一括取得（Smart Context）
+`npx -y scrapbox-cosense-mcp` で実行する（グローバルインストール済みなら `scrapbox-cosense-mcp` 直接でもよい）。
 
-詳細は `scrapbox-cosense-mcp <command> --help` で確認。
+- `npx -y scrapbox-cosense-mcp get <title>` — ページ取得
+- `npx -y scrapbox-cosense-mcp search <query>` — キーワード検索
+- `npx -y scrapbox-cosense-mcp list [--sort=X --limit=N]` — ページ一覧
+- `npx -y scrapbox-cosense-mcp create <title> [--body=TEXT]` — ページ作成（markdown自動変換）
+- `npx -y scrapbox-cosense-mcp insert <title> --after=TEXT --text=TEXT` — 行挿入
+- `npx -y scrapbox-cosense-mcp edit <title> --target=TEXT --text=TEXT [--all]` — 行置換（完全一致、既定は最初の1件のみ）
+- `npx -y scrapbox-cosense-mcp url <title>` — URL生成
+- `npx -y scrapbox-cosense-mcp context <title> [--hop=1|2]` — 関連ページ一括取得（Smart Context）
+
+詳細は `npx -y scrapbox-cosense-mcp <command> --help` で確認。
 
 全コマンド共通: `--compact` でトークン効率の高い出力、`--project=NAME` でプロジェクト指定、`--json` でJSON出力。
 


### PR DESCRIPTION
## Summary

`/plugin install scrapbox-cosense@worldnine-scrapbox-cosense-mcp` でインストールしても、MCP サーバーもスキルも登録されない空のプラグインになる問題の修正。

marketplace.json の source は npm パッケージを指しているが、`package.json` の `files` が `["build", "manifest.json"]` のみで、tarball にプラグイン構成ファイル（`.claude-plugin/plugin.json` / `.mcp.json` / `skills/`）が一切含まれていなかった（v0.8.0 の tarball を展開して確認）。

## Changes

- `package.json` の `files` に `.claude-plugin` / `.mcp.json` / `skills` を追加
- `.mcp.json` の `env` を空文字列 `""` から `${COSENSE_PROJECT_NAME:-}` / `${COSENSE_SID:-}` の環境変数展開に変更（空文字列だと利用者が settings.json 等で設定した値を上書きしてしまう）
- `skills/scrapbox/SKILL.md` のコマンドを `npx -y scrapbox-cosense-mcp` 形式に変更（プラグイン利用者は CLI をグローバルインストールしていない。`allowed-tools` は直接実行形式も残置）
- `.claude-plugin/plugin.json` の `version` を 0.5.0 → 0.8.1 に更新
- `CLAUDE.md` にプラグイン配布の仕組みを追記し、リリース手順の bump 対象に `plugin.json` を追加

.mcpb 側は既存の `.mcpbignore` がプラグイン関連ファイルを除外しているため影響なし。

## Test plan

- [x] `npm pack --dry-run` で 4 ファイル（marketplace.json / plugin.json / .mcp.json / SKILL.md）が tarball に入ることを確認（84 → 88 files）
- [x] テスト 220/220 パス、lint エラー 0
- [ ] v0.8.1 リリース後に `/plugin install` で MCP サーバーとスキルが登録されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dc27SQDzptfb6ZVM3xrr3Y
