### PR TITLE
chore: v0.8.1 リリース（Claude Code プラグイン修正）

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "scrapbox-cosense-mcp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "MCP server for Cosense/Scrapbox - Read, search, create and edit pages",
   "author": {
     "name": "worldnine"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrapbox-cosense-mcp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrapbox-cosense-mcp",
-      "version": "0.8.0",
+      "version": "0.8.1",
       "license": "MIT",
       "dependencies": {
         "@cosense/std": "npm:@jsr/cosense__std@^0.29.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrapbox-cosense-mcp",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "description": "MCP server for cosense",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## v0.8.1

### 修正

- **Claude Code プラグインが機能していなかった問題を修正**（#55）
  - `/plugin install scrapbox-cosense@worldnine-scrapbox-cosense-mcp` でインストールしても、npm パッケージにプラグイン構成ファイル（`.claude-plugin/plugin.json` / `.mcp.json` / `skills/`）が同梱されておらず、MCP サーバーもスキルも登録されない状態でした
  - v0.8.1 から npm パッケージにプラグイン一式が含まれ、プラグインとして正しく動作します
  - `.mcp.json` の環境変数を `${COSENSE_PROJECT_NAME:-}` / `${COSENSE_SID:-}` の展開形式に変更し、settings.json の `env` で設定した値が正しく反映されるようになりました
  - `/cosense` スキルのコマンドを `npx -y` 形式に変更し、CLI をグローバルインストールしていない環境でも動作するようにしました

### インストール方法

```
/plugin marketplace add worldnine/scrapbox-cosense-mcp
/plugin install scrapbox-cosense@worldnine-scrapbox-cosense-mcp
```

環境変数（`COSENSE_PROJECT_NAME`、必要なら `COSENSE_SID`）は `~/.claude/settings.json` または各プロジェクトの `.claude/settings.local.json` の `env` キーに設定してください。

### Test plan

- [x] `npm pack` でプラグイン構成ファイル 4 点の同梱を確認
- [x] テスト 220/220 パス、ビルド成功、lint エラー 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dc27SQDzptfb6ZVM3xrr3Y
