### PR TITLE
feat: オプトイン制の delete_page ツールを追加

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,7 +14,7 @@ npm run inspector    # Debug with MCP Inspector
 
 ## Architecture
 
-### Tools (8)
+### Tools (9, or 8 without `COSENSE_ENABLE_DELETE`)
 
 | Tool | Description | Auth |
 |---|---|---|
@@ -25,11 +25,12 @@ npm run inspector    # Debug with MCP Inspector
 | `get_page_url` | Generate URL from page title | - |
 | `insert_lines` | Insert text after a target line (exact match). Appends to end if not found | SID |
 | `edit_lines` | Replace a target line (exact match). Errors if not found. `matchAll` replaces every occurrence | SID |
+| `delete_page` | Delete a page by emptying every line. Registered only when `COSENSE_ENABLE_DELETE=true`. Errors if the page does not exist. `dryRun` previews | SID |
 | `get_smart_context` | Get page + linked pages (1-hop/2-hop) in AI-optimized format | SID |
 
 ### CLI
 
-All tools are also available as CLI subcommands (`get`, `list`, `search`, `create`, `url`, `insert`, `edit`, `context`). Run `scrapbox-cosense-mcp <command> --help` for usage. Key flags:
+All tools are also available as CLI subcommands (`get`, `list`, `search`, `create`, `url`, `insert`, `edit`, `delete`, `context`). `delete` requires `COSENSE_ENABLE_DELETE=true` and supports `--dry-run`. Run `scrapbox-cosense-mcp <command> --help` for usage. Key flags:
 
 - `--compact` — Token-efficient output (85% smaller for list)
 - `--json` — JSON output
@@ -64,6 +65,9 @@ All tools are also available as CLI subcommands (`get`, `list`, `search`, `creat
 - **`create_page` rejects existing pages** (`persistent === true`). Without this check, `patch()` silently replaces all content since it's a diff-update API
 - **`insert_lines` uses exact match**. Partial match risks inserting at unintended lines
 - **`edit_lines` defaults to `matchAll: false`**. Repeated lines (bullet markers, blank lines) are common, so replacing every occurrence by default would exceed what the caller asked for
+- **`delete_page` is gated by `COSENSE_ENABLE_DELETE`** at tool-registration time, not just at call time. This server is often placed in a shared MCP configuration, so an unset variable means the tool never appears in the tool list and cannot be called by mistake. The handler checks the variable again, so the CLI and direct calls are covered too
+- **`delete_page` checks existence before deleting**. The REST API returns a title line even for a page that was never created, so line count cannot tell existence apart — `persistent` does, the same way `create_page` decides. Without this check a delete against a missing page reports success
+- **`delete_page` supports `dryRun`**, which reports the line count and the first five lines without calling `patch()` at all. Deletion has no undo, so an agent should be able to look before it acts
 - **`insert_lines` and `edit_lines` differ when the target is missing**, deliberately. `insert_lines` appends to the end, since "add this text" still has a sensible landing spot. `edit_lines` errors and leaves the page untouched, since "replace this line" has no fallback — appending would silently produce a page nobody asked for
 - **`patch()` returns `Result<string, PushError>`**, not throw. Must check `result.ok`
 - **Default sort is `updated`**. Aligned across API, display, and user expectations
@@ -76,6 +80,7 @@ See README.md. Key variables:
 - `COSENSE_SID` — Session ID for private projects and write operations
 - `COSENSE_TOOL_SUFFIX` — Tool name suffix for multiple server instances
 - `COSENSE_CONVERT_NUMBERED_LISTS` — Convert numbered lists to bullet lists
+- `COSENSE_ENABLE_DELETE` — Register `delete_page` and the `delete` CLI command (opt-in)
 
 ## CI/CD & Release
 

--- a/README.md
+++ b/README.md
@@ -15,11 +15,51 @@ MCP server for [Cosense (formerly Scrapbox)](https://cosen.se).
 | `get_page_url` | Generate direct URL for a page | No |
 | `insert_lines` | Insert text after a specified line in a page | Yes |
 | `edit_lines` | Replace an exact-match line (first match, or all with `matchAll`) | Yes |
+| `delete_page` | Delete a page by emptying every line — opt-in, see below | Yes |
 | `get_smart_context` | Get a page and its linked pages (1-hop/2-hop) in AI-optimized format | Yes |
 
 `create_page`, `insert_lines`, and `edit_lines` support a `format` parameter (`"markdown"` or `"scrapbox"`) to control content conversion.
 
 `edit_lines` replaces only the first matching line by default. Set `matchAll: true` to replace every occurrence. The default is deliberately conservative: a line such as a bullet marker or a blank line can repeat many times in a page, and replacing all of them at once is rarely what the caller intended.
+
+### `delete_page` is opt-in
+
+`delete_page` is **not registered unless `COSENSE_ENABLE_DELETE=true` is set**. Without it the tool does not appear in the tool list at all, so an agent cannot call it even by mistake. This server is often added to a shared MCP configuration, so deletion is exposed only to those who deliberately turn it on.
+
+Deleting a page empties every one of its lines, and Cosense removes a page once all of its lines are empty. There is no undo. Two further guards are built in:
+
+- The page must already exist. A missing page returns an error rather than a silent success. (The REST API returns a title line even for a page that was never created, so the check looks at `persistent`, the same way `create_page` does.)
+- `dryRun: true` reports how many lines would be removed and shows the first five of them, without touching the page.
+
+When you run several instances of this server for different projects, set the variable on each instance that should be allowed to delete:
+
+```json
+{
+  "mcpServers": {
+    "cosense-notes": {
+      "command": "npx",
+      "args": ["-y", "scrapbox-cosense-mcp"],
+      "env": {
+        "COSENSE_PROJECT_NAME": "notes",
+        "COSENSE_SID": "s:your-session-id",
+        "COSENSE_TOOL_SUFFIX": "notes",
+        "COSENSE_ENABLE_DELETE": "true"
+      }
+    },
+    "cosense-archive": {
+      "command": "npx",
+      "args": ["-y", "scrapbox-cosense-mcp"],
+      "env": {
+        "COSENSE_PROJECT_NAME": "archive",
+        "COSENSE_SID": "s:your-session-id",
+        "COSENSE_TOOL_SUFFIX": "archive"
+      }
+    }
+  }
+}
+```
+
+Here the `notes` instance exposes `delete_page_notes`, while the `archive` instance exposes no deletion tool at all.
 
 Note that `insert_lines` and `edit_lines` behave differently when the target line is absent. `insert_lines` appends to the end of the page, because "add this text somewhere" still has a reasonable outcome. `edit_lines` returns an error and leaves the page untouched, because "replace this specific line" has no meaningful fallback — appending the replacement would silently produce a page the caller never asked for.
 
@@ -123,6 +163,7 @@ npm install && npm run build
 | `COSENSE_TOOL_SUFFIX` | — | Tool name suffix for multiple instances (e.g. `main` → `get_page_main`) |
 | `COSENSE_CONVERT_NUMBERED_LISTS` | `false` | Convert numbered lists to bullet lists in Markdown conversion |
 | `COSENSE_EXCLUDE_PINNED` | `false` | Exclude pinned pages from initial resource list |
+| `COSENSE_ENABLE_DELETE` | `false` | Register the `delete_page` tool and the `delete` CLI command. Without it, neither is available |
 
 ## CLI Usage
 
@@ -135,6 +176,7 @@ scrapbox-cosense-mcp list --sort=updated --limit=20
 scrapbox-cosense-mcp create "New Page" --body="Markdown content"
 scrapbox-cosense-mcp insert "Page" --after="target line" --text="new text"
 scrapbox-cosense-mcp edit "Page" --target="old line" --text="new text"
+scrapbox-cosense-mcp delete "Page" --dry-run   # needs COSENSE_ENABLE_DELETE=true
 scrapbox-cosense-mcp url "Page Title"
 ```
 

--- a/docs/README_ja.md
+++ b/docs/README_ja.md
@@ -15,10 +15,50 @@
 | `get_page_url` | ページの直接URLを生成 | 不要 |
 | `insert_lines` | ページの指定行の後にテキストを挿入 | 必要 |
 | `edit_lines` | 完全一致した行を置換（既定は最初の1件、`matchAll` で全件） | 必要 |
+| `delete_page` | 全行を空にしてページを削除（オプトイン制。下記参照） | 必要 |
 
 `create_page` と `insert_lines` と `edit_lines` は `format` パラメータ（`"markdown"` または `"scrapbox"`）でコンテンツ変換を制御できます。
 
 `edit_lines` は既定では最初に一致した行だけを置換します。全件を置換するには `matchAll: true` を指定してください。既定値を控えめにしているのは意図的です。箇条書きの記号だけの行や空行のように、同じ文字列の行がページ内に何度も現れることがあり、それらを一度にすべて置き換えるのは呼び出し側の意図と異なる場合が多いためです。
+
+### `delete_page` はオプトイン制です
+
+`delete_page` は、**`COSENSE_ENABLE_DELETE=true` を設定したときだけ登録されます**。設定していなければツール一覧にも現れないので、エージェントが誤って呼ぶこともありません。このサーバーは共有のMCP設定に入れて使われることも多いため、削除機能は意図的に有効化した利用者にだけ露出させています。
+
+ページの削除は、全ての行を空にすることで行います。Cosenseは全ての行が空になったページを自動的に削除します。取り消しはできません。さらに2つの安全策を入れてあります。
+
+- 対象のページが存在していることを確認します。存在しない場合は、黙って成功せずにエラーを返します。CosenseのREST APIは未作成のページに対してもタイトル行を返すため、行数ではなく `persistent` で判定しています。`create_page` の既存ページ判定と同じやり方です。
+- `dryRun: true` を指定すると、削除される行数と冒頭5行を報告するだけで、ページには一切触れません。
+
+プロジェクトごとに複数のインスタンスを動かしている場合は、削除を許すインスタンスにだけこの変数を設定してください。
+
+```json
+{
+  "mcpServers": {
+    "cosense-notes": {
+      "command": "npx",
+      "args": ["-y", "scrapbox-cosense-mcp"],
+      "env": {
+        "COSENSE_PROJECT_NAME": "notes",
+        "COSENSE_SID": "s:your-session-id",
+        "COSENSE_TOOL_SUFFIX": "notes",
+        "COSENSE_ENABLE_DELETE": "true"
+      }
+    },
+    "cosense-archive": {
+      "command": "npx",
+      "args": ["-y", "scrapbox-cosense-mcp"],
+      "env": {
+        "COSENSE_PROJECT_NAME": "archive",
+        "COSENSE_SID": "s:your-session-id",
+        "COSENSE_TOOL_SUFFIX": "archive"
+      }
+    }
+  }
+}
+```
+
+この例では `notes` のインスタンスだけが `delete_page_notes` を持ち、`archive` のインスタンスには削除のツールが現れません。
 
 `insert_lines` と `edit_lines` は、対象の行が見つからなかったときの挙動が異なります。`insert_lines` はページの末尾に追記します。「このテキストをどこかに足す」という要求には、末尾という妥当な着地点があるからです。`edit_lines` はエラーを返し、ページを変更しません。「この特定の行を置き換える」という要求には代わりの着地点がなく、置換内容を末尾に追記してしまえば、呼び出し側が求めていないページが黙って出来上がるためです。
 
@@ -122,6 +162,7 @@ npm install && npm run build
 | `COSENSE_TOOL_SUFFIX` | — | 複数インスタンス用のツール名サフィックス（例: `main` → `get_page_main`） |
 | `COSENSE_CONVERT_NUMBERED_LISTS` | `false` | Markdown変換時に数字付きリストを箇条書きに変換 |
 | `COSENSE_EXCLUDE_PINNED` | `false` | 初期リソース一覧からピン留めページを除外 |
+| `COSENSE_ENABLE_DELETE` | `false` | `delete_page` ツールと `delete` サブコマンドを有効にする。設定しなければどちらも使えない |
 
 ## 複数プロジェクト対応
 

--- a/skills/scrapbox/SKILL.md
+++ b/skills/scrapbox/SKILL.md
@@ -19,6 +19,7 @@ Cosense ページの取得・検索・作成・編集。CLI 経由で実行。
 - `npx -y scrapbox-cosense-mcp create <title> [--body=TEXT]` — ページ作成（markdown自動変換）
 - `npx -y scrapbox-cosense-mcp insert <title> --after=TEXT --text=TEXT` — 行挿入
 - `npx -y scrapbox-cosense-mcp edit <title> --target=TEXT --text=TEXT [--all]` — 行置換（完全一致、既定は最初の1件のみ）
+- `npx -y scrapbox-cosense-mcp delete <title> [--dry-run]` — ページ削除（`COSENSE_ENABLE_DELETE=true` が必要。取り消せないので、まず `--dry-run` で確認する）
 - `npx -y scrapbox-cosense-mcp url <title>` — URL生成
 - `npx -y scrapbox-cosense-mcp context <title> [--hop=1|2]` — 関連ページ一括取得（Smart Context）
 
@@ -33,7 +34,8 @@ Cosense ページの取得・検索・作成・編集。CLI 経由で実行。
 | 変数名 | 説明 | 必須 |
 |---|---|---|
 | `COSENSE_PROJECT_NAME` | 対象プロジェクト名（`--project` で上書き可） | はい |
-| `COSENSE_SID` | セッションID（プライベートプロジェクト、create/insert/edit/context 操作に必要） | 条件付き |
+| `COSENSE_SID` | セッションID（プライベートプロジェクト、create/insert/edit/delete/context 操作に必要） | 条件付き |
+| `COSENSE_ENABLE_DELETE` | `true` のときだけ `delete` サブコマンドが使える | いいえ |
 
 ### 永続化方法
 

--- a/src/__tests__/cli.test.ts
+++ b/src/__tests__/cli.test.ts
@@ -14,6 +14,7 @@ import * as createPageHandler from '@/routes/handlers/create-page.js';
 import * as getPageUrlHandler from '@/routes/handlers/get-page-url.js';
 import * as insertLinesHandler from '@/routes/handlers/insert-lines.js';
 import * as editLinesHandler from '@/routes/handlers/edit-lines.js';
+import * as deletePageHandler from '@/routes/handlers/delete-page.js';
 
 jest.mock('@/routes/handlers/get-page.js');
 jest.mock('@/routes/handlers/list-pages.js');
@@ -22,6 +23,7 @@ jest.mock('@/routes/handlers/create-page.js');
 jest.mock('@/routes/handlers/get-page-url.js');
 jest.mock('@/routes/handlers/insert-lines.js');
 jest.mock('@/routes/handlers/edit-lines.js');
+jest.mock('@/routes/handlers/delete-page.js');
 
 const mockedGetPage = getPageHandler as jest.Mocked<typeof getPageHandler>;
 const mockedListPages = listPagesHandler as jest.Mocked<typeof listPagesHandler>;
@@ -30,6 +32,7 @@ const mockedCreatePage = createPageHandler as jest.Mocked<typeof createPageHandl
 const mockedGetPageUrl = getPageUrlHandler as jest.Mocked<typeof getPageUrlHandler>;
 const mockedInsertLines = insertLinesHandler as jest.Mocked<typeof insertLinesHandler>;
 const mockedEditLines = editLinesHandler as jest.Mocked<typeof editLinesHandler>;
+const mockedDeletePage = deletePageHandler as jest.Mocked<typeof deletePageHandler>;
 
 // Mock process.exit to prevent test process from exiting
 const mockExit = jest.spyOn(process, 'exit').mockImplementation((() => {
@@ -373,6 +376,50 @@ describe('CLI', () => {
         // process.exit
       }
       expect(stderrOutput).toContain('--text=TEXT or --text-file=PATH is required');
+    });
+  });
+
+  describe('delete command', () => {
+    it('should call handleDeletePage with all params', async () => {
+      mockedDeletePage.handleDeletePage.mockResolvedValue(successResult);
+      try {
+        await runCli(['delete', 'My Page']);
+      } catch {
+        // process.exit
+      }
+      expect(mockedDeletePage.handleDeletePage).toHaveBeenCalledWith(
+        'test-project',
+        'test-sid',
+        {
+          pageTitle: 'My Page',
+          dryRun: false,
+          projectName: undefined,
+          compact: false,
+        }
+      );
+    });
+
+    it('should pass dryRun when --dry-run flag is set', async () => {
+      mockedDeletePage.handleDeletePage.mockResolvedValue(successResult);
+      try {
+        await runCli(['delete', 'My Page', '--dry-run']);
+      } catch {
+        // process.exit
+      }
+      expect(mockedDeletePage.handleDeletePage).toHaveBeenCalledWith(
+        'test-project',
+        'test-sid',
+        expect.objectContaining({ dryRun: true })
+      );
+    });
+
+    it('should error when page title is missing', async () => {
+      try {
+        await runCli(['delete']);
+      } catch {
+        // process.exit
+      }
+      expect(stderrOutput).toContain('Page title is required');
     });
   });
 

--- a/src/__tests__/handlers/delete-page.test.ts
+++ b/src/__tests__/handlers/delete-page.test.ts
@@ -1,0 +1,249 @@
+import { handleDeletePage, isDeleteEnabled } from '@/routes/handlers/delete-page.js';
+import * as cosense from '@/cosense.js';
+
+jest.mock('@/cosense.js');
+jest.mock('@cosense/std/websocket', () => ({
+  patch: jest.fn()
+}));
+
+const mockedCosense = cosense as jest.Mocked<typeof cosense>;
+
+let mockedPatch: jest.MockedFunction<typeof import('@cosense/std/websocket').patch>;
+beforeAll(async () => {
+  const websocketModule = await import('@cosense/std/websocket');
+  mockedPatch = websocketModule.patch as jest.MockedFunction<typeof import('@cosense/std/websocket').patch>;
+});
+
+// getPageの戻り値を組み立てる。存在するページはpersistentがtrueになる
+function mockPage(lines: string[], persistent = true) {
+  return {
+    id: 'page-id',
+    title: lines[0] ?? '',
+    lines: lines.map((text, i) => ({
+      id: `line-${i}`,
+      text,
+      userId: 'user-id',
+      created: 0,
+      updated: 0,
+    })),
+    persistent,
+    collaborators: [],
+  } as unknown as Awaited<ReturnType<typeof cosense.getPage>>;
+}
+
+describe('handleDeletePage', () => {
+  const mockProjectName = 'test-project';
+  const mockCosenseSid = 'test-sid';
+  const originalEnableDelete = process.env.COSENSE_ENABLE_DELETE;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.COSENSE_ENABLE_DELETE = 'true';
+    mockedCosense.getPage.mockResolvedValue(mockPage(['Test Page', 'line 1', 'line 2']));
+    mockedPatch.mockResolvedValue({ ok: true, val: 'commitId', err: null });
+  });
+
+  afterAll(() => {
+    if (originalEnableDelete === undefined) {
+      delete process.env.COSENSE_ENABLE_DELETE;
+    } else {
+      process.env.COSENSE_ENABLE_DELETE = originalEnableDelete;
+    }
+  });
+
+  describe('環境変数によるゲート', () => {
+    test('COSENSE_ENABLE_DELETEが未設定の場合はエラーを返し、patchを呼ばないこと', async () => {
+      delete process.env.COSENSE_ENABLE_DELETE;
+
+      const result = await handleDeletePage(mockProjectName, mockCosenseSid, {
+        pageTitle: 'Test Page',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content?.[0]?.text).toContain('COSENSE_ENABLE_DELETE');
+      expect(mockedPatch).not.toHaveBeenCalled();
+    });
+
+    test('COSENSE_ENABLE_DELETEがtrue以外の場合もエラーを返すこと', async () => {
+      process.env.COSENSE_ENABLE_DELETE = '1';
+
+      const result = await handleDeletePage(mockProjectName, mockCosenseSid, {
+        pageTitle: 'Test Page',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(mockedPatch).not.toHaveBeenCalled();
+    });
+
+    test('isDeleteEnabledが環境変数の状態を反映すること', () => {
+      process.env.COSENSE_ENABLE_DELETE = 'true';
+      expect(isDeleteEnabled()).toBe(true);
+
+      process.env.COSENSE_ENABLE_DELETE = 'false';
+      expect(isDeleteEnabled()).toBe(false);
+
+      delete process.env.COSENSE_ENABLE_DELETE;
+      expect(isDeleteEnabled()).toBe(false);
+    });
+  });
+
+  describe('認証', () => {
+    test('COSENSE_SIDが未設定の場合に認証エラーを返すこと', async () => {
+      const result = await handleDeletePage(mockProjectName, undefined, {
+        pageTitle: 'Test Page',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content?.[0]?.text).toContain('Authentication required');
+      expect(mockedPatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('存在チェック', () => {
+    test('getPageがnullを返す場合はエラーになり、patchを呼ばないこと', async () => {
+      mockedCosense.getPage.mockResolvedValue(null);
+
+      const result = await handleDeletePage(mockProjectName, mockCosenseSid, {
+        pageTitle: 'Missing Page',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content?.[0]?.text).toContain('Page not found');
+      expect(mockedPatch).not.toHaveBeenCalled();
+    });
+
+    test('存在しないページはタイトル行だけを返すが、persistentがfalseなのでエラーになること', async () => {
+      // 未作成のページに対してもAPIはタイトル行を含むレスポンスを返す。
+      // 行数だけでは存在を判定できないため、persistentで判定する
+      mockedCosense.getPage.mockResolvedValue(mockPage(['Missing Page'], false));
+
+      const result = await handleDeletePage(mockProjectName, mockCosenseSid, {
+        pageTitle: 'Missing Page',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content?.[0]?.text).toContain('Page not found');
+      expect(mockedPatch).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('ドライラン', () => {
+    test('dryRunがtrueの場合はpatchを呼ばず、行数と冒頭の行を返すこと', async () => {
+      mockedCosense.getPage.mockResolvedValue(
+        mockPage(['Test Page', 'line 1', 'line 2', 'line 3', 'line 4', 'line 5', 'line 6'])
+      );
+
+      const result = await handleDeletePage(mockProjectName, mockCosenseSid, {
+        pageTitle: 'Test Page',
+        dryRun: true,
+      });
+
+      expect(mockedPatch).not.toHaveBeenCalled();
+      const text = result.content?.[0]?.text ?? '';
+      expect(text).toContain('Dry run: no changes were made');
+      expect(text).toContain('Lines to be removed: 7');
+      expect(text).toContain('First 5 line(s):');
+      expect(text).toContain('line 4');
+      // 冒頭5行までなので6行目以降は含まれない
+      expect(text).not.toContain('line 5');
+    });
+
+    test('ページの行数が5行未満の場合は存在する行だけを返すこと', async () => {
+      mockedCosense.getPage.mockResolvedValue(mockPage(['Test Page', 'only line']));
+
+      const result = await handleDeletePage(mockProjectName, mockCosenseSid, {
+        pageTitle: 'Test Page',
+        dryRun: true,
+      });
+
+      const text = result.content?.[0]?.text ?? '';
+      expect(text).toContain('Lines to be removed: 2');
+      expect(text).toContain('First 2 line(s):');
+    });
+
+    test('compactモードのドライランでは短いメッセージを返すこと', async () => {
+      const result = await handleDeletePage(mockProjectName, mockCosenseSid, {
+        pageTitle: 'Test Page',
+        dryRun: true,
+        compact: true,
+      });
+
+      expect(mockedPatch).not.toHaveBeenCalled();
+      expect(result.content?.[0]?.text).toBe('dry-run: Test Page (3 lines) | Test Page / line 1 / line 2');
+    });
+  });
+
+  describe('削除', () => {
+    test('全ての行を空配列で置き換えること', async () => {
+      const result = await handleDeletePage(mockProjectName, mockCosenseSid, {
+        pageTitle: 'Test Page',
+      });
+
+      expect(mockedPatch).toHaveBeenCalledWith(
+        mockProjectName,
+        'Test Page',
+        expect.any(Function),
+        { sid: mockCosenseSid }
+      );
+
+      const callback = mockedPatch.mock.calls[0]?.[2] as (lines: unknown[]) => unknown[];
+      expect(callback([{ text: 'Test Page' }, { text: 'line 1' }])).toEqual([]);
+
+      const text = result.content?.[0]?.text ?? '';
+      expect(text).toContain('Successfully deleted page');
+      expect(text).toContain('Removed lines: 3');
+    });
+
+    test('projectNameの指定が既定のプロジェクトより優先されること', async () => {
+      await handleDeletePage(mockProjectName, mockCosenseSid, {
+        pageTitle: 'Test Page',
+        projectName: 'custom-project',
+      });
+
+      expect(mockedCosense.getPage).toHaveBeenCalledWith('custom-project', 'Test Page', mockCosenseSid);
+      expect(mockedPatch).toHaveBeenCalledWith(
+        'custom-project',
+        'Test Page',
+        expect.any(Function),
+        { sid: mockCosenseSid }
+      );
+    });
+
+    test('compactモードでは短いメッセージを返すこと', async () => {
+      const result = await handleDeletePage(mockProjectName, mockCosenseSid, {
+        pageTitle: 'Test Page',
+        compact: true,
+      });
+
+      expect(result.content?.[0]?.text).toBe('deleted: Test Page (3 lines)');
+    });
+  });
+
+  describe('エラー処理', () => {
+    test('patchがResult.Errを返した場合にエラーレスポンスを返すこと', async () => {
+      mockedPatch.mockResolvedValue({
+        ok: false,
+        val: null,
+        err: { name: 'NotFoundError', message: 'page not found' }
+      } as unknown as Awaited<ReturnType<typeof mockedPatch>>);
+
+      const result = await handleDeletePage(mockProjectName, mockCosenseSid, {
+        pageTitle: 'Test Page',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content?.[0]?.text).toContain('WebSocket patch failed');
+    });
+
+    test('WebSocket APIで例外が発生した場合にエラーレスポンスを返すこと', async () => {
+      mockedPatch.mockRejectedValue(new Error('socket exploded'));
+
+      const result = await handleDeletePage(mockProjectName, mockCosenseSid, {
+        pageTitle: 'Test Page',
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content?.[0]?.text).toContain('socket exploded');
+    });
+  });
+});

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -6,9 +6,10 @@ import { handleCreatePage } from './routes/handlers/create-page.js';
 import { handleGetPageUrl } from './routes/handlers/get-page-url.js';
 import { handleInsertLines } from './routes/handlers/insert-lines.js';
 import { handleEditLines } from './routes/handlers/edit-lines.js';
+import { handleDeletePage } from './routes/handlers/delete-page.js';
 import { handleGetSmartContext } from './routes/handlers/get-smart-context.js';
 
-const CLI_COMMANDS = ['get', 'list', 'search', 'create', 'url', 'insert', 'edit', 'context'] as const;
+const CLI_COMMANDS = ['get', 'list', 'search', 'create', 'url', 'insert', 'edit', 'delete', 'context'] as const;
 type CliCommand = typeof CLI_COMMANDS[number];
 
 interface ParsedArgs {
@@ -160,6 +161,20 @@ Options:
   --all                          Replace every matching line (default: first only)
 
 ${COMMON_OPTIONS}`,
+
+  delete: `Usage: scrapbox-cosense-mcp delete <title> [options]
+
+Delete a page by emptying every line. Requires COSENSE_SID and
+COSENSE_ENABLE_DELETE=true. There is no undo — run with --dry-run first.
+Fails if the page does not exist.
+
+Arguments:
+  <title>                        Page title (required)
+
+Options:
+  --dry-run                      Report what would be removed without deleting
+
+${COMMON_OPTIONS}`,
 };
 
 function printHelp(command?: string): void {
@@ -182,6 +197,7 @@ Commands:
   url <title>                    Get page URL
   insert <title>                 Insert lines into a page
   edit <title>                   Replace an exact-match line in a page
+  delete <title>                 Delete a page (requires COSENSE_ENABLE_DELETE)
   context <title>                Get smart context (related pages)
 
 ${COMMON_OPTIONS}
@@ -192,6 +208,7 @@ Environment Variables:
   COSENSE_PROJECT_NAME           Target project (required for most commands)
   COSENSE_SID                    Session ID for private projects
   COSENSE_CONVERT_NUMBERED_LISTS Convert numbered lists to bullet lists
+  COSENSE_ENABLE_DELETE          Set to true to enable the delete command
 `;
   process.stdout.write(help);
 }
@@ -420,6 +437,22 @@ export async function runCli(argv: string[]): Promise<void> {
         newText,
         format: flags['format'] === 'scrapbox' ? 'scrapbox' : undefined,
         matchAll: flags['all'] === true,
+        projectName: typeof flags['project'] === 'string' ? flags['project'] : undefined,
+        compact,
+      });
+      break;
+    }
+
+    case 'delete': {
+      const pageTitle = positional[0];
+      if (!pageTitle) {
+        process.stderr.write('Error: Page title is required. Usage: scrapbox-cosense-mcp delete <title>\n');
+        process.exit(2);
+      }
+      const project = requireProjectName(flags);
+      result = await handleDeletePage(project, sid, {
+        pageTitle,
+        dryRun: flags['dry-run'] === true,
         projectName: typeof flags['project'] === 'string' ? flags['project'] : undefined,
         compact,
       });

--- a/src/index.ts
+++ b/src/index.ts
@@ -18,6 +18,7 @@ import {
   ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
 import { listPages, getPage, toReadablePage } from "./cosense.js";
+import { isDeleteEnabled } from "./routes/handlers/delete-page.js";
 import { formatYmd } from './utils/format.js';
 import { setupRoutes } from './routes/index.js';
 
@@ -366,6 +367,30 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
           required: ["pageTitle", "targetLineText", "newText"],
         },
       },
+      // delete_page は COSENSE_ENABLE_DELETE=true のときだけ登録する。
+      // 共有のMCP設定に入れて使われることも多いため、有効にした利用者にだけ露出させる
+      ...(isDeleteEnabled() ? [{
+        name: getToolName("delete_page"),
+        description: `Delete a page in Scrapbox project on ${SERVICE_LABEL}. Empties every line of the target page via the WebSocket patch API; Cosense automatically removes a page once all of its lines are empty. There is no undo — pass dryRun to preview what would be removed first. Errors if the page does not exist. Requires COSENSE_SID. Uses ${projectName} project as default if projectName is not specified.`,
+        inputSchema: {
+          type: "object",
+          properties: {
+            pageTitle: {
+              type: "string",
+              description: "Title of the page to delete",
+            },
+            projectName: {
+              type: "string",
+              description: `Target project name. If not specified, defaults to '${projectName}'.`,
+            },
+            dryRun: {
+              type: "boolean",
+              description: "If true, report the number of lines and the first few lines that would be removed without deleting anything. Defaults to false.",
+            },
+          },
+          required: ["pageTitle"],
+        },
+      }] : []),
     ];
   
   

--- a/src/routes/handlers/delete-page.ts
+++ b/src/routes/handlers/delete-page.ts
@@ -1,0 +1,132 @@
+import { patch } from '@cosense/std/websocket';
+import { getPage } from '../../cosense.js';
+import { formatError, stringifyError } from '../../utils/format.js';
+
+export interface DeletePageParams {
+  pageTitle: string;
+  projectName?: string | undefined;
+  dryRun?: boolean | undefined;
+  compact?: boolean | undefined;
+}
+
+// ドライランで返す冒頭行の数
+const PREVIEW_LINE_COUNT = 5;
+
+export function isDeleteEnabled(): boolean {
+  return process.env.COSENSE_ENABLE_DELETE === 'true';
+}
+
+export async function handleDeletePage(
+  defaultProjectName: string,
+  cosenseSid: string | undefined,
+  params: DeletePageParams
+) {
+  const projectName = params.projectName || defaultProjectName;
+  const errorDetails = () => ({
+    Operation: 'delete_page',
+    Project: projectName,
+    Page: params.pageTitle,
+    Timestamp: new Date().toISOString(),
+  });
+
+  try {
+    // ツール登録側でもゲートしているが、CLIや直接呼び出しに備えて実行時にも確認する
+    if (!isDeleteEnabled()) {
+      return formatError(
+        'Page deletion is disabled. Set COSENSE_ENABLE_DELETE=true to enable delete_page.',
+        errorDetails(),
+        params.compact
+      );
+    }
+
+    if (!cosenseSid) {
+      return formatError(
+        'Authentication required: COSENSE_SID is needed for deleting pages',
+        errorDetails(),
+        params.compact
+      );
+    }
+
+    // 存在チェック。create_page の persistent チェックと対称にする。
+    // 存在しないページでもAPIはタイトル行だけを持つレスポンスを返すため、
+    // 行数だけでは存在を判定できない
+    const existingPage = await getPage(projectName, params.pageTitle, cosenseSid);
+    if (!existingPage || !existingPage.persistent) {
+      return formatError(
+        `Page not found: ${params.pageTitle}`,
+        errorDetails(),
+        params.compact
+      );
+    }
+
+    const lines = existingPage.lines ?? [];
+    const lineCount = lines.length;
+    const preview = lines.slice(0, PREVIEW_LINE_COUNT).map(line => line.text);
+
+    if (params.dryRun) {
+      if (params.compact) {
+        return {
+          content: [{
+            type: "text",
+            text: `dry-run: ${params.pageTitle} (${lineCount} lines) | ${preview.join(' / ')}`
+          }]
+        };
+      }
+
+      return {
+        content: [{
+          type: "text",
+          text: [
+            'Dry run: no changes were made',
+            `Operation: delete_page`,
+            `Project: ${projectName}`,
+            `Page: ${params.pageTitle}`,
+            `Lines to be removed: ${lineCount}`,
+            `First ${preview.length} line(s):`,
+            ...preview.map(text => `  ${text}`),
+            `Timestamp: ${new Date().toISOString()}`
+          ].join('\n')
+        }]
+      };
+    }
+
+    // 全行を空配列にする。Cosenseは全ての行が空になったページを自動的に削除する
+    const result = await patch(projectName, params.pageTitle, () => [], {
+      sid: cosenseSid,
+    });
+
+    if (!result.ok) {
+      throw new Error(`WebSocket patch failed: ${stringifyError(result.err)}`);
+    }
+
+    if (params.compact) {
+      return {
+        content: [{
+          type: "text",
+          text: `deleted: ${params.pageTitle} (${lineCount} lines)`
+        }]
+      };
+    }
+
+    return {
+      content: [{
+        type: "text",
+        text: [
+          'Successfully deleted page',
+          `Operation: delete_page`,
+          `Project: ${projectName}`,
+          `Page: ${params.pageTitle}`,
+          `Removed lines: ${lineCount}`,
+          `Timestamp: ${new Date().toISOString()}`
+        ].join('\n')
+      }]
+    };
+
+  } catch (error) {
+    return formatError(
+      error instanceof Error ? error.message : 'Unknown error',
+      errorDetails(),
+      params.compact
+    );
+  }
+}

--- a/src/routes/handlers/edit-lines.ts
+++ b/src/routes/handlers/edit-lines.ts
@@ -43,6 +43,8 @@ export async function handleEditLines(
     let replacedCount = 0;
 
     const result = await patch(projectName, params.pageTitle, (lines: BaseLine[]) => {
+      // patchがコンフリクトでリトライした場合に前回の結果が残らないようリセットする
+      replacedCount = 0;
       const matchedIndices: number[] = [];
       for (let i = 0; i < lines.length; i++) {
         if (lines[i]?.text === params.targetLineText) {

--- a/src/routes/index.ts
+++ b/src/routes/index.ts
@@ -8,6 +8,7 @@ import { handleGetPageUrl } from './handlers/get-page-url.js';
 import { handleInsertLines } from './handlers/insert-lines.js';
 import { handleGetSmartContext } from './handlers/get-smart-context.js';
 import { handleEditLines } from './handlers/edit-lines.js';
+import { handleDeletePage } from './handlers/delete-page.js';
 
 // ツール名正規化ヘルパー
 function normalizeToolName(toolName: string, toolSuffix?: string): string {
@@ -108,6 +109,18 @@ export function setupRoutes(
             projectName: request.params.arguments?.projectName as string | undefined,
             format: (request.params.arguments?.format as "markdown" | "scrapbox" | undefined) ?? undefined,
             matchAll: request.params.arguments?.matchAll as boolean | undefined,
+            compact: request.params.arguments?.compact as boolean | undefined,
+          }
+        );
+
+      case "delete_page":
+        return handleDeletePage(
+          projectName,
+          cosenseSid,
+          {
+            pageTitle: String(request.params.arguments?.pageTitle),
+            projectName: request.params.arguments?.projectName as string | undefined,
+            dryRun: request.params.arguments?.dryRun as boolean | undefined,
             compact: request.params.arguments?.compact as boolean | undefined,
           }
         );


### PR DESCRIPTION
Issue #51 でご相談していた2本のうち、2本目です。`delete_page` と、`#52` でご指摘いただいた `replacedCount` の修正を含みます。

## 安全策

Issue でお願いされた3点をすべて入れました。

**環境変数によるオプトイン** — `COSENSE_ENABLE_DELETE=true` のときだけツールを登録します。設定していなければツール一覧にも現れません。ハンドラの側でも同じ変数を確認しているので、CLI や直接の呼び出しも塞いであります。有効にしていない状態で呼ばれた場合は、その変数が必要である旨を明示したエラーを返します。

**実行前の存在チェック** — `create_page` と対称に `persistent` を確認し、存在しないページはエラーで返します。

**ドライラン** — `dryRun: true` のときは `patch` を一切呼ばず、削除される行数と冒頭5行だけを返します。存在チェックで取得した本文をそのまま使うので、API の呼び出しは増えません。行数は5行にしましたが、ご意見があれば合わせます。

## ご指摘いただいた不具合の再現と修正

存在チェックが無いと成功扱いになるというご指摘は、実機でも再現しました。ページを削除したあとに REST API を直接叩くと、次のレスポンスが返ります。

```
persistent = false
lines数 = 1
lines = ["delete page実機確認 2026-08-06"]
```

存在しないページに対しても API はタイトル行を1行返すため、行数では存在を判定できません。フォークの実装はこの1行を見て `hadContent` を true と判断し、「Successfully deleted / Removed lines: 1」を返していました。ご指摘のとおりです。今回は `persistent` で判定するようにしました。

テストも直しました。フォークのテストは「空のページ」をモックで `lines: []` として渡していて、実運用では起きない状況を検証していました。今回は「タイトル行だけが返り `persistent` が false のページ」を検証しています。

## `replacedCount` の修正（#52 のご指摘）

`edit_lines` のコールバックの冒頭に `replacedCount = 0` を追加しました。`patch` がコンフリクトでリトライした際に前回の結果が残る問題を防ぎます。

## 更新したドキュメント

- README.md と docs/README_ja.md — ツール表、`delete_page` がオプトイン制であることの説明、環境変数の表、CLI の使用例。複数のインスタンスを並べる場合の設定例も添えました。有効にしたインスタンスにだけ `delete_page` が現れることが分かる形にしています
- CLAUDE.md — ツール表（`COSENSE_ENABLE_DELETE` の有無で 8 か 9 になる旨）、CLI サブコマンドの一覧、設計判断のセクションに3点を理由込みで追記
- skills/scrapbox/SKILL.md — コマンド一覧と環境変数の表

## 確認したこと

`npm test` は 227 件が成功しました。`delete_page` のハンドラのテストを14件、CLI のテストを3件追加しています。`npm run lint` はエラー0件、警告29件で、変更前と同じ件数です。

MCP サーバーとして実際に起動して `tools/list` を問い合わせ、環境変数の状態でツールの数が変わることを確認しました。

| 環境変数 | ツール数 | `delete_page` |
|---|---|---|
| 未設定 | 8 | 現れない |
| `false` | 8 | 現れない |
| `true` | 9 | 現れる |

実際の Cosense に対しても通しで確認しました。確認用のページを8行で作り、環境変数なしでの拒否、ドライラン（ページが変更されないことを取得して確認）、実際の削除、削除後に同じページをもう一度削除しようとした場合のエラーまで、順に確かめています。

`package.json` と `manifest.json` の `version` は触っていません。
