### PR TITLE
chore: v0.9.0 リリース準備

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "scrapbox-cosense",
   "description": "Scrapbox/Cosense integration - read, search, create, and edit wiki pages",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "author": {
     "name": "worldnine"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "scrapbox-cosense-mcp",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "MCP server for Cosense/Scrapbox - Read, search, create and edit pages",
   "author": {
     "name": "worldnine"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrapbox-cosense-mcp",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrapbox-cosense-mcp",
-      "version": "0.8.1",
+      "version": "0.9.0",
       "license": "MIT",
       "dependencies": {
         "@cosense/std": "npm:@jsr/cosense__std@^0.29.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrapbox-cosense-mcp",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "description": "MCP server for cosense",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## 概要

v0.9.0 のリリース準備です。`package.json`・`manifest.json`・`.claude-plugin/plugin.json`・`package-lock.json` のバージョンを 0.9.0 に更新しました。

## 変更内容（v0.8.1 からの差分）

- **feat: オプトイン制の `delete_page` ツールを追加**（#57、@qurihara さんのコントリビューション、Issue #51）
  - `COSENSE_ENABLE_DELETE=true` のときだけツールが登録されるオプトイン制
  - 実行前の存在チェック（`persistent` による判定）
  - `dryRun` による削除内容のプレビュー
  - CLI に `delete` サブコマンドを追加
- **fix: `edit_lines` の `replacedCount` がリトライ時に残留する問題を修正**（#57 に同梱、#52 のレビュー指摘）

マージ後はタグ作成 → npm 公開 → GitHub Release → .mcpb 添付まで自動で進みます。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dc27SQDzptfb6ZVM3xrr3Y
