### PR TITLE
release: v0.10.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "scrapbox-cosense",
   "description": "Scrapbox/Cosense integration - read, search, create, and edit wiki pages",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "author": {
     "name": "worldnine"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "scrapbox-cosense-mcp",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "MCP server for Cosense/Scrapbox - Read, search, create and edit pages",
   "author": {
     "name": "worldnine"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrapbox-cosense-mcp",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrapbox-cosense-mcp",
-      "version": "0.9.0",
+      "version": "0.10.0",
       "license": "MIT",
       "dependencies": {
         "@cosense/std": "npm:@jsr/cosense__std@^0.29.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrapbox-cosense-mcp",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "description": "MCP server for cosense",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## v0.10.0

### 新機能

- **edit_lines**: 改行を含む `targetLineText` を連続行ブロックとして扱い、複数行（n行→m行）の置換に対応しました（#59 の提案、#63）
- **delete_lines**（新ツール）: 完全一致（複数行ブロック対応）で行を削除します。`matchAll` で全件削除。タイトル行の削除は暗黙リネーム防止のため拒否します
- **rewrite_page**（新ツール）: ページ全体を新しい内容に置換します。`COSENSE_ENABLE_DELETE=true` のときのみ登録されます。存在しないページ・空内容は拒否、`dryRun` で before/after をプレビューできます
- **CLI**: `delete-lines` / `rewrite` サブコマンドを追加（`rewrite` は `--dry-run` 対応）

### `COSENSE_ENABLE_DELETE` 設定済みユーザーへ

このバージョンから `COSENSE_ENABLE_DELETE=true` は `delete_page` に加えて `rewrite_page` も有効化します。rewrite_page は既に許可されている `delete_page` + `create_page` の合成と同等の操作であり、新しい破壊能力を追加するものではありません（存在チェック・dryRun 付きの分、より安全です）。

### 変更なし

既存ツールの挙動に破壊的変更はありません。`edit_lines` は従来どおり単一行指定ならこれまでと同じ動作です。

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01VTLktgSU58AWVFGeqqsExh