### PR TITLE
fix: Glama ビルドプローブ失敗の修正(prompts/list・resources/templates/list の空ハンドラ追加、serverInfo version の package.json 化)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -101,6 +101,7 @@ See README.md. Key variables:
 ### Release Process
 
 1. Create `release/vX.Y.Z` branch, bump version in `package.json` + `manifest.json` + `.claude-plugin/plugin.json`
+   - Note: the MCP `serverInfo.version` is read from `package.json` at runtime, so no separate bump is needed for `src/index.ts`
 2. Create PR → CI passes → merge
 3. Everything after merge is automatic (tag → npm → GitHub Release → .mcpb)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -13,10 +13,17 @@ const TOOL_SUFFIX = process.env.COSENSE_TOOL_SUFFIX;
 import { Server } from "@modelcontextprotocol/sdk/server/index.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
 import {
+  ListPromptsRequestSchema,
+  ListResourceTemplatesRequestSchema,
   ListResourcesRequestSchema,
   ListToolsRequestSchema,
   ReadResourceRequestSchema,
 } from "@modelcontextprotocol/sdk/types.js";
+import { createRequire } from "node:module";
+
+// package.json を唯一のバージョン情報源にする（リリース時のズレ防止）
+const require = createRequire(import.meta.url);
+const { version } = require("../package.json") as { version: string };
 import { listPages, getPage, toReadablePage } from "./cosense.js";
 import { isDeleteEnabled } from "./routes/handlers/delete-page.js";
 import { formatYmd } from './utils/format.js';
@@ -99,7 +106,7 @@ const resources = await (async () => {
 const server = new Server(
   {
     name: "scrapbox-cosense-mcp",
-    version: "0.5.0",
+    version,
   },
   {
     capabilities: {
@@ -155,6 +162,17 @@ server.setRequestHandler(ReadResourceRequestSchema, async (request) => {
       },
     ],
   };
+});
+
+// この SDK は capabilities で宣言したメソッドしかハンドラ登録できないため、
+// prompts / resource templates は宣言とセットで空の list ハンドラを用意する。
+// （未登録のままにするとクライアントの probes が -32601 Method not found を受ける）
+server.setRequestHandler(ListPromptsRequestSchema, async () => {
+  return { prompts: [] };
+});
+
+server.setRequestHandler(ListResourceTemplatesRequestSchema, async () => {
+  return { resourceTemplates: [] };
 });
 
 server.setRequestHandler(ListToolsRequestSchema, async () => {


### PR DESCRIPTION
## 背景

Glama (MCP サーバーレジストリ) から「build failed」通知が届く。ログを確認したところ **Docker ビルド自体は成功**しており、失敗したのはビルド後のプローブ。

## 原因

プローブが  を呼んだ際に  を返していた。

-  は capabilities で  を宣言しているのに  ハンドラを未登録のままだった
- MCP 仕様上、宣言した機能の list メソッドは処理できなければならない
- 同様に  も宣言から呼ばれ得るが未登録だった

## 修正内容

1. ** → `{ prompts: [] }`** と **`resources/templates/list` → `{ resourceTemplates: [] }`** の空ハンドラを追加
   - この SDK は capabilities で宣言したメソッドしかハンドラ登録できないため、 の宣言は維持したままハンドラを追加する形が正解
2. ** のハードコード (0.5.0) を撤廃**し、package.json から実行時に読むよう変更
   - リリース時に package.json とのズレが生じる構造的バグの修正。CLAUDE.md のリリース手順にも注記を追記

## 検証

- Glama と同じ手順 (initialize → tools/list → prompts/list → resources/templates/list) を stdio で再現 → エラー応答なし
-  が 0.10.0 になることを確認
- テスト 273 件すべて成功、lint エラーなし