### PR TITLE
release: v0.10.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "scrapbox-cosense",
   "description": "Scrapbox/Cosense integration - read, search, create, and edit wiki pages",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "author": {
     "name": "worldnine"
   },

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": "0.3",
   "name": "scrapbox-cosense-mcp",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "MCP server for Cosense/Scrapbox - Read, search, create and edit pages",
   "author": {
     "name": "worldnine"

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "scrapbox-cosense-mcp",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "scrapbox-cosense-mcp",
-      "version": "0.10.0",
+      "version": "0.10.1",
       "license": "MIT",
       "dependencies": {
         "@cosense/std": "npm:@jsr/cosense__std@^0.29.8",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "scrapbox-cosense-mcp",
-  "version": "0.10.0",
+  "version": "0.10.1",
   "description": "MCP server for cosense",
   "private": false,
   "license": "MIT",


### PR DESCRIPTION
## 内容

v0.10.1 リリース準備(バージョンバンプのみ)。

## 含まれる修正

- #65 fix: prompts/list と resources/templates/list の空ハンドラ追加、serverInfo version の package.json 化
  - Glama のビルドプローブが -32601 Method not found で失敗する問題の修正