### PR TITLE
feat: COSENSE_PROJECT_ALLOW_LIST による操作対象プロジェクトの制限

### DIFF
--- a/src/__tests__/cli-project-allow-list.test.ts
+++ b/src/__tests__/cli-project-allow-list.test.ts
@@ -1,0 +1,95 @@
+// ハンドラはモックしない。CLI がプロジェクト名をどう渡すかまで含めて確認したいため
+jest.mock('@cosense/std/websocket', () => ({
+  patch: jest.fn()
+}));
+jest.mock('@/cosense.js');
+
+import { runCli } from '@/cli.js';
+
+const mockExit = jest.spyOn(process, 'exit').mockImplementation((() => {
+  throw new Error('process.exit called');
+}) as never);
+
+let stdoutOutput: string;
+let stderrOutput: string;
+jest.spyOn(process.stdout, 'write').mockImplementation((chunk) => {
+  stdoutOutput += String(chunk);
+  return true;
+});
+jest.spyOn(process.stderr, 'write').mockImplementation((chunk) => {
+  stderrOutput += String(chunk);
+  return true;
+});
+
+async function run(argv: string[]): Promise<void> {
+  try {
+    await runCli(argv);
+  } catch (error) {
+    // process.exit のモックが投げる例外だけを飲み込む
+    if (!(error instanceof Error) || error.message !== 'process.exit called') throw error;
+  }
+}
+
+/**
+ * CLI は `--project=NAME` の値をハンドラの第1引数（既定プロジェクト名）としても渡す。
+ * 許可リストの暗黙の既定プロジェクトを引数から取ると、この経路だけ判定が素通りになる。
+ */
+describe('CLI での COSENSE_PROJECT_ALLOW_LIST', () => {
+  const originalAllowList = process.env.COSENSE_PROJECT_ALLOW_LIST;
+  const originalProjectName = process.env.COSENSE_PROJECT_NAME;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    stdoutOutput = '';
+    stderrOutput = '';
+    process.env.COSENSE_PROJECT_NAME = 'allowed-default';
+    process.env.COSENSE_PROJECT_ALLOW_LIST = 'allowed-default';
+  });
+
+  afterAll(() => {
+    if (originalAllowList === undefined) {
+      delete process.env.COSENSE_PROJECT_ALLOW_LIST;
+    } else {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = originalAllowList;
+    }
+    if (originalProjectName === undefined) {
+      delete process.env.COSENSE_PROJECT_NAME;
+    } else {
+      process.env.COSENSE_PROJECT_NAME = originalProjectName;
+    }
+    jest.restoreAllMocks();
+  });
+
+  test('--project で許可外のプロジェクトを指定するとエラー終了すること', async () => {
+    await run(['url', 'TestPage', '--project=forbidden-project']);
+
+    expect(stderrOutput).toContain("Project 'forbidden-project' is not allowed");
+    expect(stdoutOutput).not.toContain('forbidden-project');
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  test('読み取り系サブコマンドでも弾かれること', async () => {
+    await run(['get', 'TestPage', '--project=forbidden-project']);
+
+    expect(stderrOutput).toContain("Project 'forbidden-project' is not allowed");
+    expect(mockExit).toHaveBeenCalledWith(1);
+  });
+
+  test('--project で許可済みのプロジェクトを指定すれば通ること', async () => {
+    process.env.COSENSE_PROJECT_ALLOW_LIST = 'allowed-default,other-project';
+
+    await run(['url', 'TestPage', '--project=other-project']);
+
+    expect(stderrOutput).not.toContain('is not allowed');
+    expect(mockExit).toHaveBeenCalledWith(0);
+  });
+
+  test('許可リストが未設定なら --project は従来どおり自由に指定できること', async () => {
+    delete process.env.COSENSE_PROJECT_ALLOW_LIST;
+
+    await run(['url', 'TestPage', '--project=any-project']);
+
+    expect(stderrOutput).not.toContain('is not allowed');
+    expect(mockExit).toHaveBeenCalledWith(0);
+  });
+});

--- a/src/__tests__/handlers/project-allow-list.test.ts
+++ b/src/__tests__/handlers/project-allow-list.test.ts
@@ -1,0 +1,176 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+import { handleCreatePage } from '@/routes/handlers/create-page.js';
+import { handleDeleteLines } from '@/routes/handlers/delete-lines.js';
+import { handleDeletePage } from '@/routes/handlers/delete-page.js';
+import { handleEditLines } from '@/routes/handlers/edit-lines.js';
+import { handleGetPage } from '@/routes/handlers/get-page.js';
+import { handleGetPageUrl } from '@/routes/handlers/get-page-url.js';
+import { handleGetSmartContext } from '@/routes/handlers/get-smart-context.js';
+import { handleInsertLines } from '@/routes/handlers/insert-lines.js';
+import { handleListPages } from '@/routes/handlers/list-pages.js';
+import { handleRewritePage } from '@/routes/handlers/rewrite-page.js';
+import { handleSearchPages } from '@/routes/handlers/search-pages.js';
+
+import * as cosense from '@/cosense.js';
+
+jest.mock('@/cosense.js');
+jest.mock('@cosense/std/websocket', () => ({
+  patch: jest.fn()
+}));
+
+const mockedCosense = cosense as jest.Mocked<typeof cosense>;
+
+let mockedPatch: jest.MockedFunction<typeof import('@cosense/std/websocket').patch>;
+beforeAll(async () => {
+  const websocketModule = await import('@cosense/std/websocket');
+  mockedPatch = websocketModule.patch as jest.MockedFunction<typeof import('@cosense/std/websocket').patch>;
+});
+
+type Handler = (
+  defaultProjectName: string,
+  cosenseSid: string | undefined,
+  params: never
+) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+
+/**
+ * 全ハンドラの一覧。許可リストの判定は各ハンドラに1行ずつ置いてあるため、
+ * ツールを足した人が書き忘れると素通りしてしまう。ここで全ハンドラを列挙し、
+ * さらに下のテストで「ファイルはあるのに列挙されていない」を落とす。
+ */
+const HANDLERS: Array<{ file: string; call: (projectName: string) => Promise<unknown> }> = [
+  {
+    file: 'create-page.ts',
+    call: p => (handleCreatePage as Handler)('default-project', 'sid', { title: 'Page', projectName: p } as never),
+  },
+  {
+    file: 'delete-lines.ts',
+    call: p => (handleDeleteLines as Handler)('default-project', 'sid', { pageTitle: 'Page', targetLineText: 'line', projectName: p } as never),
+  },
+  {
+    file: 'delete-page.ts',
+    call: p => (handleDeletePage as Handler)('default-project', 'sid', { pageTitle: 'Page', projectName: p } as never),
+  },
+  {
+    file: 'edit-lines.ts',
+    call: p => (handleEditLines as Handler)('default-project', 'sid', { pageTitle: 'Page', targetLineText: 'line', newText: 'new', projectName: p } as never),
+  },
+  {
+    file: 'get-page.ts',
+    call: p => (handleGetPage as Handler)('default-project', 'sid', { pageTitle: 'Page', projectName: p } as never),
+  },
+  {
+    file: 'get-page-url.ts',
+    call: p => (handleGetPageUrl as Handler)('default-project', 'sid', { title: 'Page', projectName: p } as never),
+  },
+  {
+    file: 'get-smart-context.ts',
+    call: p => (handleGetSmartContext as Handler)('default-project', 'sid', { title: 'Page', projectName: p } as never),
+  },
+  {
+    file: 'insert-lines.ts',
+    call: p => (handleInsertLines as Handler)('default-project', 'sid', { pageTitle: 'Page', targetLineText: 'line', text: 'text', projectName: p } as never),
+  },
+  {
+    file: 'list-pages.ts',
+    call: p => (handleListPages as Handler)('default-project', 'sid', { projectName: p } as never),
+  },
+  {
+    file: 'rewrite-page.ts',
+    call: p => (handleRewritePage as Handler)('default-project', 'sid', { pageTitle: 'Page', body: 'body', projectName: p } as never),
+  },
+  {
+    file: 'search-pages.ts',
+    call: p => (handleSearchPages as Handler)('default-project', 'sid', { query: 'q', projectName: p } as never),
+  },
+];
+
+// src/routes/handlers の実ディレクトリ。テスト実行時のcwdは通常リポジトリルート
+function findHandlersDir(): string {
+  let dir = process.cwd();
+  for (let i = 0; i < 5; i++) {
+    const candidate = path.join(dir, 'src', 'routes', 'handlers');
+    if (fs.existsSync(candidate)) return candidate;
+    dir = path.dirname(dir);
+  }
+  throw new Error('src/routes/handlers が見つかりませんでした');
+}
+
+function resultText(result: unknown): string {
+  const content = (result as { content?: Array<{ text?: string }> }).content ?? [];
+  return content.map(c => c.text ?? '').join('\n');
+}
+
+describe('COSENSE_PROJECT_ALLOW_LIST が全ハンドラに効くこと', () => {
+  const originalAllowList = process.env.COSENSE_PROJECT_ALLOW_LIST;
+  const originalEnableDelete = process.env.COSENSE_ENABLE_DELETE;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // 破壊的ツールが「無効だから」ではなく「許可外だから」落ちることを見たいので有効にしておく
+    process.env.COSENSE_ENABLE_DELETE = 'true';
+  });
+
+  afterAll(() => {
+    if (originalAllowList === undefined) {
+      delete process.env.COSENSE_PROJECT_ALLOW_LIST;
+    } else {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = originalAllowList;
+    }
+    if (originalEnableDelete === undefined) {
+      delete process.env.COSENSE_ENABLE_DELETE;
+    } else {
+      process.env.COSENSE_ENABLE_DELETE = originalEnableDelete;
+    }
+  });
+
+  test('ハンドラのファイルがすべて列挙されていること', () => {
+    const files = fs.readdirSync(findHandlersDir())
+      .filter(name => name.endsWith('.ts'))
+      .sort();
+    const listed = HANDLERS.map(h => h.file).sort();
+    // 新しいツールを足したらここが落ちる。許可リストの判定を入れて、このテストに追加すること
+    expect(listed).toEqual(files);
+  });
+
+  describe.each(HANDLERS)('$file', ({ call }) => {
+    test('許可外のプロジェクトを指定するとエラーになること', async () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'allowed-project';
+
+      const result = await call('forbidden-project') as { isError?: boolean };
+
+      expect(result.isError).toBe(true);
+      expect(resultText(result)).toContain("Project 'forbidden-project' is not allowed");
+    });
+
+    test('許可外なら Cosense API を一切呼ばないこと', async () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'allowed-project';
+
+      await call('forbidden-project');
+
+      expect(mockedPatch).not.toHaveBeenCalled();
+      expect(mockedCosense.getPage).not.toHaveBeenCalled();
+      expect(mockedCosense.listPages).not.toHaveBeenCalled();
+      expect(mockedCosense.searchPages).not.toHaveBeenCalled();
+      expect(mockedCosense.getSmartContext).not.toHaveBeenCalled();
+      expect(mockedCosense.createPageUrl).not.toHaveBeenCalled();
+    });
+
+    test('許可リストが未設定なら許可リスト由来のエラーは出ないこと', async () => {
+      delete process.env.COSENSE_PROJECT_ALLOW_LIST;
+
+      const result = await call('any-project');
+
+      expect(resultText(result)).not.toContain('is not allowed');
+    });
+
+    test('既定プロジェクトはリストに書かれていなくても弾かれないこと', async () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'allowed-project';
+
+      const result = await call('default-project');
+
+      expect(resultText(result)).not.toContain('is not allowed');
+    });
+  });
+});

--- a/src/__tests__/handlers/project-allow-list.test.ts
+++ b/src/__tests__/handlers/project-allow-list.test.ts
@@ -39,50 +39,53 @@ type Handler = (
  * ツールを足した人が書き忘れると素通りしてしまう。ここで全ハンドラを列挙し、
  * さらに下のテストで「ファイルはあるのに列挙されていない」を落とす。
  */
-const HANDLERS: Array<{ file: string; call: (projectName: string) => Promise<unknown> }> = [
+const HANDLERS: Array<{
+  file: string;
+  call: (defaultProjectName: string, projectName?: string) => Promise<unknown>;
+}> = [
   {
     file: 'create-page.ts',
-    call: p => (handleCreatePage as Handler)('default-project', 'sid', { title: 'Page', projectName: p } as never),
+    call: (d, p) => (handleCreatePage as Handler)(d, 'sid', { title: 'Page', projectName: p } as never),
   },
   {
     file: 'delete-lines.ts',
-    call: p => (handleDeleteLines as Handler)('default-project', 'sid', { pageTitle: 'Page', targetLineText: 'line', projectName: p } as never),
+    call: (d, p) => (handleDeleteLines as Handler)(d, 'sid', { pageTitle: 'Page', targetLineText: 'line', projectName: p } as never),
   },
   {
     file: 'delete-page.ts',
-    call: p => (handleDeletePage as Handler)('default-project', 'sid', { pageTitle: 'Page', projectName: p } as never),
+    call: (d, p) => (handleDeletePage as Handler)(d, 'sid', { pageTitle: 'Page', projectName: p } as never),
   },
   {
     file: 'edit-lines.ts',
-    call: p => (handleEditLines as Handler)('default-project', 'sid', { pageTitle: 'Page', targetLineText: 'line', newText: 'new', projectName: p } as never),
+    call: (d, p) => (handleEditLines as Handler)(d, 'sid', { pageTitle: 'Page', targetLineText: 'line', newText: 'new', projectName: p } as never),
   },
   {
     file: 'get-page.ts',
-    call: p => (handleGetPage as Handler)('default-project', 'sid', { pageTitle: 'Page', projectName: p } as never),
+    call: (d, p) => (handleGetPage as Handler)(d, 'sid', { pageTitle: 'Page', projectName: p } as never),
   },
   {
     file: 'get-page-url.ts',
-    call: p => (handleGetPageUrl as Handler)('default-project', 'sid', { title: 'Page', projectName: p } as never),
+    call: (d, p) => (handleGetPageUrl as Handler)(d, 'sid', { title: 'Page', projectName: p } as never),
   },
   {
     file: 'get-smart-context.ts',
-    call: p => (handleGetSmartContext as Handler)('default-project', 'sid', { title: 'Page', projectName: p } as never),
+    call: (d, p) => (handleGetSmartContext as Handler)(d, 'sid', { title: 'Page', projectName: p } as never),
   },
   {
     file: 'insert-lines.ts',
-    call: p => (handleInsertLines as Handler)('default-project', 'sid', { pageTitle: 'Page', targetLineText: 'line', text: 'text', projectName: p } as never),
+    call: (d, p) => (handleInsertLines as Handler)(d, 'sid', { pageTitle: 'Page', targetLineText: 'line', text: 'text', projectName: p } as never),
   },
   {
     file: 'list-pages.ts',
-    call: p => (handleListPages as Handler)('default-project', 'sid', { projectName: p } as never),
+    call: (d, p) => (handleListPages as Handler)(d, 'sid', { projectName: p } as never),
   },
   {
     file: 'rewrite-page.ts',
-    call: p => (handleRewritePage as Handler)('default-project', 'sid', { pageTitle: 'Page', body: 'body', projectName: p } as never),
+    call: (d, p) => (handleRewritePage as Handler)(d, 'sid', { pageTitle: 'Page', body: 'body', projectName: p } as never),
   },
   {
     file: 'search-pages.ts',
-    call: p => (handleSearchPages as Handler)('default-project', 'sid', { query: 'q', projectName: p } as never),
+    call: (d, p) => (handleSearchPages as Handler)(d, 'sid', { query: 'q', projectName: p } as never),
   },
 ];
 
@@ -105,11 +108,13 @@ function resultText(result: unknown): string {
 describe('COSENSE_PROJECT_ALLOW_LIST が全ハンドラに効くこと', () => {
   const originalAllowList = process.env.COSENSE_PROJECT_ALLOW_LIST;
   const originalEnableDelete = process.env.COSENSE_ENABLE_DELETE;
+  const originalProjectName = process.env.COSENSE_PROJECT_NAME;
 
   beforeEach(() => {
     jest.clearAllMocks();
     // 破壊的ツールが「無効だから」ではなく「許可外だから」落ちることを見たいので有効にしておく
     process.env.COSENSE_ENABLE_DELETE = 'true';
+    process.env.COSENSE_PROJECT_NAME = 'default-project';
   });
 
   afterAll(() => {
@@ -122,6 +127,11 @@ describe('COSENSE_PROJECT_ALLOW_LIST が全ハンドラに効くこと', () => {
       delete process.env.COSENSE_ENABLE_DELETE;
     } else {
       process.env.COSENSE_ENABLE_DELETE = originalEnableDelete;
+    }
+    if (originalProjectName === undefined) {
+      delete process.env.COSENSE_PROJECT_NAME;
+    } else {
+      process.env.COSENSE_PROJECT_NAME = originalProjectName;
     }
   });
 
@@ -138,7 +148,7 @@ describe('COSENSE_PROJECT_ALLOW_LIST が全ハンドラに効くこと', () => {
     test('許可外のプロジェクトを指定するとエラーになること', async () => {
       process.env.COSENSE_PROJECT_ALLOW_LIST = 'allowed-project';
 
-      const result = await call('forbidden-project') as { isError?: boolean };
+      const result = await call('default-project', 'forbidden-project') as { isError?: boolean };
 
       expect(result.isError).toBe(true);
       expect(resultText(result)).toContain("Project 'forbidden-project' is not allowed");
@@ -147,7 +157,7 @@ describe('COSENSE_PROJECT_ALLOW_LIST が全ハンドラに効くこと', () => {
     test('許可外なら Cosense API を一切呼ばないこと', async () => {
       process.env.COSENSE_PROJECT_ALLOW_LIST = 'allowed-project';
 
-      await call('forbidden-project');
+      await call('default-project', 'forbidden-project');
 
       expect(mockedPatch).not.toHaveBeenCalled();
       expect(mockedCosense.getPage).not.toHaveBeenCalled();
@@ -157,10 +167,22 @@ describe('COSENSE_PROJECT_ALLOW_LIST が全ハンドラに効くこと', () => {
       expect(mockedCosense.createPageUrl).not.toHaveBeenCalled();
     });
 
+    test('CLI の --project 相当（既定プロジェクト名としても渡る）でも弾かれること', async () => {
+      // CLI は --project=NAME の値を defaultProjectName としてハンドラに渡し、params.projectName は空になる。
+      // 暗黙の既定プロジェクトを引数から取ると、この経路だけ許可リストが素通りする
+      process.env.COSENSE_PROJECT_NAME = 'allowed-project';
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'allowed-project';
+
+      const result = await call('forbidden-project') as { isError?: boolean };
+
+      expect(result.isError).toBe(true);
+      expect(resultText(result)).toContain("Project 'forbidden-project' is not allowed");
+    });
+
     test('許可リストが未設定なら許可リスト由来のエラーは出ないこと', async () => {
       delete process.env.COSENSE_PROJECT_ALLOW_LIST;
 
-      const result = await call('any-project');
+      const result = await call('default-project', 'any-project');
 
       expect(resultText(result)).not.toContain('is not allowed');
     });
@@ -168,7 +190,7 @@ describe('COSENSE_PROJECT_ALLOW_LIST が全ハンドラに効くこと', () => {
     test('既定プロジェクトはリストに書かれていなくても弾かれないこと', async () => {
       process.env.COSENSE_PROJECT_ALLOW_LIST = 'allowed-project';
 
-      const result = await call('default-project');
+      const result = await call('default-project', 'default-project');
 
       expect(resultText(result)).not.toContain('is not allowed');
     });

--- a/src/__tests__/utils/project.test.ts
+++ b/src/__tests__/utils/project.test.ts
@@ -7,12 +7,22 @@ import {
 
 describe('COSENSE_PROJECT_ALLOW_LIST', () => {
   const originalAllowList = process.env.COSENSE_PROJECT_ALLOW_LIST;
+  const originalProjectName = process.env.COSENSE_PROJECT_NAME;
+
+  beforeEach(() => {
+    process.env.COSENSE_PROJECT_NAME = 'default-project';
+  });
 
   afterEach(() => {
     if (originalAllowList === undefined) {
       delete process.env.COSENSE_PROJECT_ALLOW_LIST;
     } else {
       process.env.COSENSE_PROJECT_ALLOW_LIST = originalAllowList;
+    }
+    if (originalProjectName === undefined) {
+      delete process.env.COSENSE_PROJECT_NAME;
+    } else {
+      process.env.COSENSE_PROJECT_NAME = originalProjectName;
     }
   });
 
@@ -53,40 +63,49 @@ describe('COSENSE_PROJECT_ALLOW_LIST', () => {
   describe('isProjectAllowed', () => {
     test('未設定ならどのプロジェクトも許可されること（後方互換）', () => {
       delete process.env.COSENSE_PROJECT_ALLOW_LIST;
-      expect(isProjectAllowed('anything', 'default-project')).toBe(true);
+      expect(isProjectAllowed('anything')).toBe(true);
     });
 
     test('リストに含まれるプロジェクトを許可すること', () => {
       process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha,beta';
-      expect(isProjectAllowed('beta', 'default-project')).toBe(true);
+      expect(isProjectAllowed('beta')).toBe(true);
     });
 
     test('リストに無いプロジェクトを拒否すること', () => {
       process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha,beta';
-      expect(isProjectAllowed('gamma', 'default-project')).toBe(false);
+      expect(isProjectAllowed('gamma')).toBe(false);
     });
 
     test('既定プロジェクトはリストに書かれていなくても許可されること', () => {
       process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha';
-      expect(isProjectAllowed('default-project', 'default-project')).toBe(true);
+      expect(isProjectAllowed('default-project')).toBe(true);
     });
 
     test('大文字小文字を区別すること', () => {
       process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha';
-      expect(isProjectAllowed('Alpha', 'default-project')).toBe(false);
+      expect(isProjectAllowed('Alpha')).toBe(false);
     });
 
-    test('既定プロジェクトが未指定でもリストだけで判定できること', () => {
+    test('COSENSE_PROJECT_NAME が未設定でもリストだけで判定できること', () => {
+      delete process.env.COSENSE_PROJECT_NAME;
       process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha';
-      expect(isProjectAllowed('alpha', undefined)).toBe(true);
-      expect(isProjectAllowed('beta', undefined)).toBe(false);
+      expect(isProjectAllowed('alpha')).toBe(true);
+      expect(isProjectAllowed('beta')).toBe(false);
+    });
+
+    test('既定プロジェクトの判定に呼び出し側の引数を使わないこと', () => {
+      // CLI は --project=NAME の値をそのまま defaultProjectName としてハンドラに渡すため、
+      // 引数を基準にすると「指定した名前＝既定」が常に成立して許可リストが素通りになる
+      process.env.COSENSE_PROJECT_NAME = 'allowed-default';
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'allowed-default';
+      expect(isProjectAllowed('forbidden-project')).toBe(false);
     });
   });
 
   describe('projectNotAllowedMessage', () => {
     test('許可済みプロジェクトの一覧を含むこと', () => {
       process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha,beta';
-      const message = projectNotAllowedMessage('gamma', 'default-project');
+      const message = projectNotAllowedMessage('gamma');
       expect(message).toContain("Project 'gamma' is not allowed");
       expect(message).toContain('COSENSE_PROJECT_ALLOW_LIST');
       expect(message).toContain('default-project, alpha, beta');
@@ -94,12 +113,12 @@ describe('COSENSE_PROJECT_ALLOW_LIST', () => {
 
     test('暗黙に許可される既定プロジェクトを一覧に含めること', () => {
       process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha';
-      expect(projectNotAllowedMessage('gamma', 'default-project')).toContain('default-project');
+      expect(projectNotAllowedMessage('gamma')).toContain('default-project');
     });
 
     test('既定プロジェクトがリストにもある場合に重複させないこと', () => {
       process.env.COSENSE_PROJECT_ALLOW_LIST = 'default-project,alpha';
-      expect(projectNotAllowedMessage('gamma', 'default-project'))
+      expect(projectNotAllowedMessage('gamma'))
         .toContain('Permitted projects: default-project, alpha');
     });
   });
@@ -107,18 +126,18 @@ describe('COSENSE_PROJECT_ALLOW_LIST', () => {
   describe('checkProjectAllowed', () => {
     test('許可されていれば undefined を返すこと', () => {
       process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha';
-      expect(checkProjectAllowed('alpha', 'default-project')).toBeUndefined();
+      expect(checkProjectAllowed('alpha')).toBeUndefined();
     });
 
     test('未設定なら undefined を返すこと', () => {
       delete process.env.COSENSE_PROJECT_ALLOW_LIST;
-      expect(checkProjectAllowed('anything', 'default-project')).toBeUndefined();
+      expect(checkProjectAllowed('anything')).toBeUndefined();
     });
 
     test('拒否時はメッセージ文字列を返すこと（例外は投げない）', () => {
       process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha';
-      expect(checkProjectAllowed('gamma', 'default-project'))
-        .toBe(projectNotAllowedMessage('gamma', 'default-project'));
+      expect(checkProjectAllowed('gamma'))
+        .toBe(projectNotAllowedMessage('gamma'));
     });
   });
 });

--- a/src/__tests__/utils/project.test.ts
+++ b/src/__tests__/utils/project.test.ts
@@ -1,0 +1,124 @@
+import {
+  getProjectAllowList,
+  isProjectAllowed,
+  projectNotAllowedMessage,
+  checkProjectAllowed,
+} from '@/utils/project.js';
+
+describe('COSENSE_PROJECT_ALLOW_LIST', () => {
+  const originalAllowList = process.env.COSENSE_PROJECT_ALLOW_LIST;
+
+  afterEach(() => {
+    if (originalAllowList === undefined) {
+      delete process.env.COSENSE_PROJECT_ALLOW_LIST;
+    } else {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = originalAllowList;
+    }
+  });
+
+  describe('getProjectAllowList', () => {
+    test('未設定なら undefined（無制限）を返すこと', () => {
+      delete process.env.COSENSE_PROJECT_ALLOW_LIST;
+      expect(getProjectAllowList()).toBeUndefined();
+    });
+
+    test('空文字・空白のみなら undefined を返すこと', () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = '   ';
+      expect(getProjectAllowList()).toBeUndefined();
+    });
+
+    test('カンマ区切りを分割すること', () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha,beta';
+      expect(getProjectAllowList()).toEqual(['alpha', 'beta']);
+    });
+
+    test('各要素の前後の空白をトリムし、空要素を無視すること', () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = ' alpha , , beta ,';
+      expect(getProjectAllowList()).toEqual(['alpha', 'beta']);
+    });
+
+    test('カンマだけなら undefined を返すこと', () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = ',,,';
+      expect(getProjectAllowList()).toBeUndefined();
+    });
+
+    test('呼び出しごとに環境変数を読み直すこと', () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha';
+      expect(getProjectAllowList()).toEqual(['alpha']);
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'beta';
+      expect(getProjectAllowList()).toEqual(['beta']);
+    });
+  });
+
+  describe('isProjectAllowed', () => {
+    test('未設定ならどのプロジェクトも許可されること（後方互換）', () => {
+      delete process.env.COSENSE_PROJECT_ALLOW_LIST;
+      expect(isProjectAllowed('anything', 'default-project')).toBe(true);
+    });
+
+    test('リストに含まれるプロジェクトを許可すること', () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha,beta';
+      expect(isProjectAllowed('beta', 'default-project')).toBe(true);
+    });
+
+    test('リストに無いプロジェクトを拒否すること', () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha,beta';
+      expect(isProjectAllowed('gamma', 'default-project')).toBe(false);
+    });
+
+    test('既定プロジェクトはリストに書かれていなくても許可されること', () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha';
+      expect(isProjectAllowed('default-project', 'default-project')).toBe(true);
+    });
+
+    test('大文字小文字を区別すること', () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha';
+      expect(isProjectAllowed('Alpha', 'default-project')).toBe(false);
+    });
+
+    test('既定プロジェクトが未指定でもリストだけで判定できること', () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha';
+      expect(isProjectAllowed('alpha', undefined)).toBe(true);
+      expect(isProjectAllowed('beta', undefined)).toBe(false);
+    });
+  });
+
+  describe('projectNotAllowedMessage', () => {
+    test('許可済みプロジェクトの一覧を含むこと', () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha,beta';
+      const message = projectNotAllowedMessage('gamma', 'default-project');
+      expect(message).toContain("Project 'gamma' is not allowed");
+      expect(message).toContain('COSENSE_PROJECT_ALLOW_LIST');
+      expect(message).toContain('default-project, alpha, beta');
+    });
+
+    test('暗黙に許可される既定プロジェクトを一覧に含めること', () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha';
+      expect(projectNotAllowedMessage('gamma', 'default-project')).toContain('default-project');
+    });
+
+    test('既定プロジェクトがリストにもある場合に重複させないこと', () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'default-project,alpha';
+      expect(projectNotAllowedMessage('gamma', 'default-project'))
+        .toContain('Permitted projects: default-project, alpha');
+    });
+  });
+
+  describe('checkProjectAllowed', () => {
+    test('許可されていれば undefined を返すこと', () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha';
+      expect(checkProjectAllowed('alpha', 'default-project')).toBeUndefined();
+    });
+
+    test('未設定なら undefined を返すこと', () => {
+      delete process.env.COSENSE_PROJECT_ALLOW_LIST;
+      expect(checkProjectAllowed('anything', 'default-project')).toBeUndefined();
+    });
+
+    test('拒否時はメッセージ文字列を返すこと（例外は投げない）', () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha';
+      expect(checkProjectAllowed('gamma', 'default-project'))
+        .toBe(projectNotAllowedMessage('gamma', 'default-project'));
+    });
+  });
+});

--- a/src/__tests__/utils/project.test.ts
+++ b/src/__tests__/utils/project.test.ts
@@ -32,9 +32,14 @@ describe('COSENSE_PROJECT_ALLOW_LIST', () => {
       expect(getProjectAllowList()).toBeUndefined();
     });
 
-    test('空文字・空白のみなら undefined を返すこと', () => {
+    test('空白のみなら空配列を返すこと（設定されている以上は制限モード）', () => {
       process.env.COSENSE_PROJECT_ALLOW_LIST = '   ';
-      expect(getProjectAllowList()).toBeUndefined();
+      expect(getProjectAllowList()).toEqual([]);
+    });
+
+    test('空文字なら空配列を返すこと', () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = '';
+      expect(getProjectAllowList()).toEqual([]);
     });
 
     test('カンマ区切りを分割すること', () => {
@@ -47,9 +52,9 @@ describe('COSENSE_PROJECT_ALLOW_LIST', () => {
       expect(getProjectAllowList()).toEqual(['alpha', 'beta']);
     });
 
-    test('カンマだけなら undefined を返すこと', () => {
+    test('カンマだけなら空配列を返すこと', () => {
       process.env.COSENSE_PROJECT_ALLOW_LIST = ',,,';
-      expect(getProjectAllowList()).toBeUndefined();
+      expect(getProjectAllowList()).toEqual([]);
     });
 
     test('呼び出しごとに環境変数を読み直すこと', () => {
@@ -79,6 +84,19 @@ describe('COSENSE_PROJECT_ALLOW_LIST', () => {
     test('既定プロジェクトはリストに書かれていなくても許可されること', () => {
       process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha';
       expect(isProjectAllowed('default-project')).toBe(true);
+    });
+
+    test('実質空の許可リストなら既定プロジェクトだけが許可されること', () => {
+      // 「設定したつもりで無制限」より「既定プロジェクトだけ許可」に倒す
+      process.env.COSENSE_PROJECT_ALLOW_LIST = ',,,';
+      expect(isProjectAllowed('default-project')).toBe(true);
+      expect(isProjectAllowed('alpha')).toBe(false);
+    });
+
+    test('空文字の許可リストでも制限がかかること', () => {
+      process.env.COSENSE_PROJECT_ALLOW_LIST = '';
+      expect(isProjectAllowed('default-project')).toBe(true);
+      expect(isProjectAllowed('alpha')).toBe(false);
     });
 
     test('大文字小文字を区別すること', () => {
@@ -114,6 +132,12 @@ describe('COSENSE_PROJECT_ALLOW_LIST', () => {
     test('暗黙に許可される既定プロジェクトを一覧に含めること', () => {
       process.env.COSENSE_PROJECT_ALLOW_LIST = 'alpha';
       expect(projectNotAllowedMessage('gamma')).toContain('default-project');
+    });
+
+    test('許可されるものが1つも無ければ (none) と出すこと', () => {
+      delete process.env.COSENSE_PROJECT_NAME;
+      process.env.COSENSE_PROJECT_ALLOW_LIST = ',,,';
+      expect(projectNotAllowedMessage('gamma')).toContain('Permitted projects: (none)');
     });
 
     test('既定プロジェクトがリストにもある場合に重複させないこと', () => {

--- a/src/routes/handlers/create-page.ts
+++ b/src/routes/handlers/create-page.ts
@@ -1,6 +1,7 @@
 import { createPageUrl, getPage } from "../../cosense.js";
 import { convertMarkdownToScrapbox } from '../../utils/markdown-converter.js';
 import { formatError, stringifyError } from '../../utils/format.js';
+import { checkProjectAllowed } from '../../utils/project.js';
 import { patch } from '@cosense/std/websocket';
 import type { BaseLine } from '@cosense/types/rest';
 
@@ -20,6 +21,17 @@ export async function handleCreatePage(
 ) {
   try {
     const projectName = params.projectName || defaultProjectName;
+
+    const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+    if (notAllowed) {
+      return formatError(notAllowed, {
+        Operation: 'create_page',
+        Project: projectName,
+        Title: String(params.title),
+        Timestamp: new Date().toISOString(),
+      }, params.compact);
+    }
+
     const title = String(params.title);
     const body = params.body;
     const createActually = params.createActually !== false; // デフォルトtrue

--- a/src/routes/handlers/create-page.ts
+++ b/src/routes/handlers/create-page.ts
@@ -22,7 +22,7 @@ export async function handleCreatePage(
   try {
     const projectName = params.projectName || defaultProjectName;
 
-    const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+    const notAllowed = checkProjectAllowed(projectName);
     if (notAllowed) {
       return formatError(notAllowed, {
         Operation: 'create_page',

--- a/src/routes/handlers/delete-lines.ts
+++ b/src/routes/handlers/delete-lines.ts
@@ -18,7 +18,7 @@ export async function handleDeleteLines(
 ) {
   const projectName = params.projectName || defaultProjectName;
 
-  const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+  const notAllowed = checkProjectAllowed(projectName);
   if (notAllowed) {
     return formatError(notAllowed, {
       Operation: 'delete_lines',

--- a/src/routes/handlers/delete-lines.ts
+++ b/src/routes/handlers/delete-lines.ts
@@ -1,6 +1,7 @@
 import { patch } from '@cosense/std/websocket';
 import type { BaseLine } from '@cosense/types/rest';
 import { formatError, stringifyError } from '../../utils/format.js';
+import { checkProjectAllowed } from '../../utils/project.js';
 
 export interface DeleteLinesParams {
   pageTitle: string;
@@ -16,6 +17,16 @@ export async function handleDeleteLines(
   params: DeleteLinesParams
 ) {
   const projectName = params.projectName || defaultProjectName;
+
+  const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+  if (notAllowed) {
+    return formatError(notAllowed, {
+      Operation: 'delete_lines',
+      Project: projectName,
+      Page: params.pageTitle,
+      Timestamp: new Date().toISOString(),
+    }, params.compact);
+  }
 
   try {
     if (!cosenseSid) {

--- a/src/routes/handlers/delete-page.ts
+++ b/src/routes/handlers/delete-page.ts
@@ -1,6 +1,7 @@
 import { patch } from '@cosense/std/websocket';
 import { getPage } from '../../cosense.js';
 import { formatError, stringifyError } from '../../utils/format.js';
+import { checkProjectAllowed } from '../../utils/project.js';
 
 export interface DeletePageParams {
   pageTitle: string;
@@ -28,6 +29,11 @@ export async function handleDeletePage(
     Page: params.pageTitle,
     Timestamp: new Date().toISOString(),
   });
+
+  const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+  if (notAllowed) {
+    return formatError(notAllowed, errorDetails(), params.compact);
+  }
 
   try {
     // ツール登録側でもゲートしているが、CLIや直接呼び出しに備えて実行時にも確認する

--- a/src/routes/handlers/delete-page.ts
+++ b/src/routes/handlers/delete-page.ts
@@ -30,7 +30,7 @@ export async function handleDeletePage(
     Timestamp: new Date().toISOString(),
   });
 
-  const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+  const notAllowed = checkProjectAllowed(projectName);
   if (notAllowed) {
     return formatError(notAllowed, errorDetails(), params.compact);
   }

--- a/src/routes/handlers/edit-lines.ts
+++ b/src/routes/handlers/edit-lines.ts
@@ -2,6 +2,7 @@ import { patch } from '@cosense/std/websocket';
 import type { BaseLine } from '@cosense/types/rest';
 import { convertMarkdownToScrapbox } from '../../utils/markdown-converter.js';
 import { formatError, stringifyError } from '../../utils/format.js';
+import { checkProjectAllowed } from '../../utils/project.js';
 
 export interface EditLinesParams {
   pageTitle: string;
@@ -19,6 +20,16 @@ export async function handleEditLines(
   params: EditLinesParams
 ) {
   const projectName = params.projectName || defaultProjectName;
+
+  const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+  if (notAllowed) {
+    return formatError(notAllowed, {
+      Operation: 'edit_lines',
+      Project: projectName,
+      Page: params.pageTitle,
+      Timestamp: new Date().toISOString(),
+    }, params.compact);
+  }
 
   try {
     if (!cosenseSid) {

--- a/src/routes/handlers/edit-lines.ts
+++ b/src/routes/handlers/edit-lines.ts
@@ -21,7 +21,7 @@ export async function handleEditLines(
 ) {
   const projectName = params.projectName || defaultProjectName;
 
-  const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+  const notAllowed = checkProjectAllowed(projectName);
   if (notAllowed) {
     return formatError(notAllowed, {
       Operation: 'edit_lines',

--- a/src/routes/handlers/get-page-url.ts
+++ b/src/routes/handlers/get-page-url.ts
@@ -1,4 +1,5 @@
 import { createPageUrl } from "../../cosense.js";
+import { checkProjectAllowed } from '../../utils/project.js';
 
 export interface GetPageUrlParams {
   title: string;
@@ -12,6 +13,25 @@ export async function handleGetPageUrl(
 ) {
   try {
     const projectName = params.projectName || defaultProjectName;
+
+    const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+    if (notAllowed) {
+      return {
+        content: [{
+          type: "text",
+          text: [
+            'Error details:',
+            `Message: ${notAllowed}`,
+            `Operation: get_page_url`,
+            `Project: ${projectName}`,
+            `Title: ${params.title}`,
+            `Timestamp: ${new Date().toISOString()}`
+          ].join('\n')
+        }],
+        isError: true
+      };
+    }
+
     const title = String(params.title);
     const url = createPageUrl(projectName, title);
     

--- a/src/routes/handlers/get-page-url.ts
+++ b/src/routes/handlers/get-page-url.ts
@@ -14,7 +14,7 @@ export async function handleGetPageUrl(
   try {
     const projectName = params.projectName || defaultProjectName;
 
-    const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+    const notAllowed = checkProjectAllowed(projectName);
     if (notAllowed) {
       return {
         content: [{

--- a/src/routes/handlers/get-page.ts
+++ b/src/routes/handlers/get-page.ts
@@ -16,7 +16,7 @@ export async function handleGetPage(
   try {
     const projectName = params.projectName || defaultProjectName;
 
-    const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+    const notAllowed = checkProjectAllowed(projectName);
     if (notAllowed) {
       return formatError(notAllowed, {
         Operation: 'get_page',

--- a/src/routes/handlers/get-page.ts
+++ b/src/routes/handlers/get-page.ts
@@ -1,5 +1,6 @@
 import { getPage, toReadablePage } from "../../cosense.js";
 import { formatYmd, formatError } from '../../utils/format.js';
+import { checkProjectAllowed } from '../../utils/project.js';
 
 export interface GetPageParams {
   pageTitle: string;
@@ -14,6 +15,17 @@ export async function handleGetPage(
 ) {
   try {
     const projectName = params.projectName || defaultProjectName;
+
+    const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+    if (notAllowed) {
+      return formatError(notAllowed, {
+        Operation: 'get_page',
+        Project: projectName,
+        Page: params.pageTitle,
+        Timestamp: new Date().toISOString(),
+      }, params.compact);
+    }
+
     const page = await getPage(projectName, params.pageTitle, cosenseSid);
 
     if (!page) {

--- a/src/routes/handlers/get-smart-context.ts
+++ b/src/routes/handlers/get-smart-context.ts
@@ -17,7 +17,7 @@ export async function handleGetSmartContext(
   try {
     const projectName = params.projectName || defaultProjectName;
 
-    const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+    const notAllowed = checkProjectAllowed(projectName);
     if (notAllowed) {
       return formatError(notAllowed, {
         Operation: 'get_smart_context',

--- a/src/routes/handlers/get-smart-context.ts
+++ b/src/routes/handlers/get-smart-context.ts
@@ -1,5 +1,6 @@
 import { getSmartContext } from "../../cosense.js";
 import { formatError } from '../../utils/format.js';
+import { checkProjectAllowed } from '../../utils/project.js';
 
 export interface GetSmartContextParams {
   title: string;
@@ -15,6 +16,16 @@ export async function handleGetSmartContext(
 ) {
   try {
     const projectName = params.projectName || defaultProjectName;
+
+    const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+    if (notAllowed) {
+      return formatError(notAllowed, {
+        Operation: 'get_smart_context',
+        Project: projectName,
+        Page: params.title,
+        Timestamp: new Date().toISOString(),
+      }, params.compact);
+    }
 
     if (!cosenseSid) {
       return formatError(

--- a/src/routes/handlers/insert-lines.ts
+++ b/src/routes/handlers/insert-lines.ts
@@ -21,7 +21,7 @@ export async function handleInsertLines(
   try {
     const projectName = params.projectName || defaultProjectName;
 
-    const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+    const notAllowed = checkProjectAllowed(projectName);
     if (notAllowed) {
       return formatError(notAllowed, {
         Operation: 'insert_lines',

--- a/src/routes/handlers/insert-lines.ts
+++ b/src/routes/handlers/insert-lines.ts
@@ -2,6 +2,7 @@ import { patch } from '@cosense/std/websocket';
 import type { BaseLine } from '@cosense/types/rest';
 import { convertMarkdownToScrapbox } from '../../utils/markdown-converter.js';
 import { formatError, stringifyError } from '../../utils/format.js';
+import { checkProjectAllowed } from '../../utils/project.js';
 
 export interface InsertLinesParams {
   pageTitle: string;
@@ -19,6 +20,16 @@ export async function handleInsertLines(
 ) {
   try {
     const projectName = params.projectName || defaultProjectName;
+
+    const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+    if (notAllowed) {
+      return formatError(notAllowed, {
+        Operation: 'insert_lines',
+        Project: projectName,
+        Page: params.pageTitle,
+        Timestamp: new Date().toISOString(),
+      }, params.compact);
+    }
 
     if (!cosenseSid) {
       return formatError('Authentication required: COSENSE_SID is needed for page editing', {

--- a/src/routes/handlers/list-pages.ts
+++ b/src/routes/handlers/list-pages.ts
@@ -28,7 +28,7 @@ export async function handleListPages(
     } = params;
     const projectName = paramsProjectName || defaultProjectName;
 
-    const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+    const notAllowed = checkProjectAllowed(projectName);
     if (notAllowed) {
       return formatError(notAllowed, {
         Operation: 'list_pages',

--- a/src/routes/handlers/list-pages.ts
+++ b/src/routes/handlers/list-pages.ts
@@ -1,6 +1,7 @@
 import { type ListPagesResponse } from "../../cosense.js";
 import { listPages, listPagesWithSort } from "../../cosense.js";
 import { formatPageOutput, formatPageCompact, formatError, getSortDescription, getSortValue } from '../../utils/format.js';
+import { checkProjectAllowed } from '../../utils/project.js';
 
 export interface ListPagesParams {
   sort?: string;
@@ -26,6 +27,16 @@ export async function handleListPages(
       compact = false
     } = params;
     const projectName = paramsProjectName || defaultProjectName;
+
+    const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+    if (notAllowed) {
+      return formatError(notAllowed, {
+        Operation: 'list_pages',
+        Project: projectName,
+        Timestamp: new Date().toISOString(),
+      }, compact);
+    }
+
     let pages;
 
     if (excludePinned) {

--- a/src/routes/handlers/rewrite-page.ts
+++ b/src/routes/handlers/rewrite-page.ts
@@ -2,6 +2,7 @@ import { patch } from '@cosense/std/websocket';
 import { getPage } from '../../cosense.js';
 import { convertMarkdownToScrapbox } from '../../utils/markdown-converter.js';
 import { formatError, stringifyError } from '../../utils/format.js';
+import { checkProjectAllowed } from '../../utils/project.js';
 import { isDeleteEnabled } from './delete-page.js';
 
 export interface RewritePageParams {
@@ -28,6 +29,11 @@ export async function handleRewritePage(
     Page: params.pageTitle,
     Timestamp: new Date().toISOString(),
   });
+
+  const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+  if (notAllowed) {
+    return formatError(notAllowed, errorDetails(), params.compact);
+  }
 
   try {
     // ツール登録側でもゲートしているが、CLIや直接呼び出しに備えて実行時にも確認する

--- a/src/routes/handlers/rewrite-page.ts
+++ b/src/routes/handlers/rewrite-page.ts
@@ -30,7 +30,7 @@ export async function handleRewritePage(
     Timestamp: new Date().toISOString(),
   });
 
-  const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+  const notAllowed = checkProjectAllowed(projectName);
   if (notAllowed) {
     return formatError(notAllowed, errorDetails(), params.compact);
   }

--- a/src/routes/handlers/search-pages.ts
+++ b/src/routes/handlers/search-pages.ts
@@ -16,7 +16,7 @@ export async function handleSearchPages(
   try {
     const projectName = params.projectName || defaultProjectName;
 
-    const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+    const notAllowed = checkProjectAllowed(projectName);
     if (notAllowed) {
       return formatError(notAllowed, {
         Operation: 'search_pages',

--- a/src/routes/handlers/search-pages.ts
+++ b/src/routes/handlers/search-pages.ts
@@ -1,5 +1,6 @@
 import { searchPages } from "../../cosense.js";
 import { formatPageOutput, formatPageCompact, formatError } from '../../utils/format.js';
+import { checkProjectAllowed } from '../../utils/project.js';
 
 export interface SearchPagesParams {
   query: string;
@@ -14,6 +15,17 @@ export async function handleSearchPages(
 ) {
   try {
     const projectName = params.projectName || defaultProjectName;
+
+    const notAllowed = checkProjectAllowed(projectName, defaultProjectName);
+    if (notAllowed) {
+      return formatError(notAllowed, {
+        Operation: 'search_pages',
+        Project: projectName,
+        Query: String(params.query),
+        Timestamp: new Date().toISOString(),
+      }, params.compact);
+    }
+
     const query = String(params.query);
     const results = await searchPages(projectName, query, cosenseSid);
 

--- a/src/utils/project.ts
+++ b/src/utils/project.ts
@@ -1,12 +1,12 @@
 /**
  * 操作対象プロジェクトの制限（`COSENSE_PROJECT_ALLOW_LIST`）。
  *
- * 全ツールはパラメータで `projectName` の上書きを受け付ける。これはマルチプロジェクトを
- * 扱うための意図的な仕様であって、塞ぐべき穴ではない。ただし SID が届く範囲は既定プロジェクト
- * より広いことが多く、LLM が誤って別プロジェクトを指したときの歯止めが無い。
+ * 全ツールはパラメータで `projectName` の上書きを受け付ける。マルチプロジェクトを扱うための
+ * 意図的な仕様だが、SID が届く範囲は既定プロジェクトより広いことが多く、LLM が誤って別の
+ * プロジェクトを指したときの歯止めが無い。
  *
- * 未設定なら従来どおり無制限（後方互換）。絞りたい人だけ絞る、オプトインの安全策。
- * `COSENSE_ENABLE_DELETE` と同じく、環境変数は呼び出しごとに読む。
+ * 未設定なら従来どおり無制限（後方互換）。`COSENSE_ENABLE_DELETE` と同じく、絞りたい人だけ
+ * 絞るオプトインの安全策で、環境変数は呼び出しごとに読む。
  */
 
 /** 許可リストを環境変数から読む。未設定・空なら undefined（＝無制限）。 */
@@ -19,19 +19,27 @@ export function getProjectAllowList(): string[] | undefined {
 }
 
 /**
+ * 暗黙に許可される既定プロジェクト。
+ *
+ * ハンドラが受け取る `defaultProjectName` ではなく環境変数を見る。CLI は `--project=NAME` の
+ * 値をそのまま `defaultProjectName` としてハンドラに渡すため、引数を基準にすると
+ * 「指定した名前＝既定」が常に成立して、許可リストが素通りになる。
+ */
+function getDefaultProjectName(): string | undefined {
+  return process.env.COSENSE_PROJECT_NAME?.trim() || undefined;
+}
+
+/**
  * 指定されたプロジェクトが許可されているか判定する。
  * 既定プロジェクト（`COSENSE_PROJECT_NAME`）は暗黙にリストに含まれる扱い。
  *
  * 照合は大文字小文字を区別する。Scrapbox のページ解決は寛容だが、ここまで寛容にすると
  * 表記違いで許可外のプロジェクトが通ってしまうため。
  */
-export function isProjectAllowed(
-  projectName: string,
-  defaultProjectName: string | undefined
-): boolean {
+export function isProjectAllowed(projectName: string): boolean {
   const allowList = getProjectAllowList();
   if (!allowList) return true;
-  if (defaultProjectName && projectName === defaultProjectName) return true;
+  if (projectName === getDefaultProjectName()) return true;
   return allowList.includes(projectName);
 }
 
@@ -39,10 +47,8 @@ export function isProjectAllowed(
  * 拒否時のメッセージ。許可済みの一覧をそのまま見せる — 隠しても攻撃者には効かず、
  * 設定ミスを直す人が困るだけなので。
  */
-export function projectNotAllowedMessage(
-  projectName: string,
-  defaultProjectName: string | undefined
-): string {
+export function projectNotAllowedMessage(projectName: string): string {
+  const defaultProjectName = getDefaultProjectName();
   // 既定プロジェクトは暗黙に許可されるので、案内にも含めないと嘘になる
   const permitted = [
     ...(defaultProjectName ? [defaultProjectName] : []),
@@ -59,10 +65,7 @@ export function projectNotAllowedMessage(
  * あるため。投げるとそこだけ catch されない。呼び出し側は受け取った文字列を
  * それぞれの `formatError` に載せる。
  */
-export function checkProjectAllowed(
-  projectName: string,
-  defaultProjectName: string | undefined
-): string | undefined {
-  if (isProjectAllowed(projectName, defaultProjectName)) return undefined;
-  return projectNotAllowedMessage(projectName, defaultProjectName);
+export function checkProjectAllowed(projectName: string): string | undefined {
+  if (isProjectAllowed(projectName)) return undefined;
+  return projectNotAllowedMessage(projectName);
 }

--- a/src/utils/project.ts
+++ b/src/utils/project.ts
@@ -9,13 +9,18 @@
  * 絞るオプトインの安全策で、環境変数は呼び出しごとに読む。
  */
 
-/** 許可リストを環境変数から読む。未設定・空なら undefined（＝無制限）。 */
+/**
+ * 許可リストを環境変数から読む。**未設定のときだけ** undefined（＝無制限）。
+ *
+ * 設定されていれば、トリム後に名前が1つも残らなくても（`""` や `",,,"`）空配列を返して
+ * 制限モードに入る。変数を書いた人は制限したい意図なので、「設定したつもりで無制限」より
+ * 「既定プロジェクトだけ許可」に倒すほうが安全なため。
+ */
 export function getProjectAllowList(): string[] | undefined {
-  const raw = process.env.COSENSE_PROJECT_ALLOW_LIST?.trim();
-  if (!raw) return undefined;
+  const raw = process.env.COSENSE_PROJECT_ALLOW_LIST;
+  if (raw === undefined) return undefined;
   // カンマ区切りの各要素は前後の空白をトリムし、空要素は無視する
-  const list = raw.split(',').map(name => name.trim()).filter(Boolean);
-  return list.length > 0 ? list : undefined;
+  return raw.split(',').map(name => name.trim()).filter(Boolean);
 }
 
 /**
@@ -55,7 +60,9 @@ export function projectNotAllowedMessage(projectName: string): string {
     ...(getProjectAllowList() ?? []),
   ];
   const unique = permitted.filter((name, index) => permitted.indexOf(name) === index);
-  return `Project '${projectName}' is not allowed by COSENSE_PROJECT_ALLOW_LIST. Permitted projects: ${unique.join(', ')}`;
+  // 実質空の許可リストで COSENSE_PROJECT_NAME も無いと、許可されるものが1つも無い
+  const listed = unique.length > 0 ? unique.join(', ') : '(none)';
+  return `Project '${projectName}' is not allowed by COSENSE_PROJECT_ALLOW_LIST. Permitted projects: ${listed}`;
 }
 
 /**

--- a/src/utils/project.ts
+++ b/src/utils/project.ts
@@ -1,0 +1,68 @@
+/**
+ * 操作対象プロジェクトの制限（`COSENSE_PROJECT_ALLOW_LIST`）。
+ *
+ * 全ツールはパラメータで `projectName` の上書きを受け付ける。これはマルチプロジェクトを
+ * 扱うための意図的な仕様であって、塞ぐべき穴ではない。ただし SID が届く範囲は既定プロジェクト
+ * より広いことが多く、LLM が誤って別プロジェクトを指したときの歯止めが無い。
+ *
+ * 未設定なら従来どおり無制限（後方互換）。絞りたい人だけ絞る、オプトインの安全策。
+ * `COSENSE_ENABLE_DELETE` と同じく、環境変数は呼び出しごとに読む。
+ */
+
+/** 許可リストを環境変数から読む。未設定・空なら undefined（＝無制限）。 */
+export function getProjectAllowList(): string[] | undefined {
+  const raw = process.env.COSENSE_PROJECT_ALLOW_LIST?.trim();
+  if (!raw) return undefined;
+  // カンマ区切りの各要素は前後の空白をトリムし、空要素は無視する
+  const list = raw.split(',').map(name => name.trim()).filter(Boolean);
+  return list.length > 0 ? list : undefined;
+}
+
+/**
+ * 指定されたプロジェクトが許可されているか判定する。
+ * 既定プロジェクト（`COSENSE_PROJECT_NAME`）は暗黙にリストに含まれる扱い。
+ *
+ * 照合は大文字小文字を区別する。Scrapbox のページ解決は寛容だが、ここまで寛容にすると
+ * 表記違いで許可外のプロジェクトが通ってしまうため。
+ */
+export function isProjectAllowed(
+  projectName: string,
+  defaultProjectName: string | undefined
+): boolean {
+  const allowList = getProjectAllowList();
+  if (!allowList) return true;
+  if (defaultProjectName && projectName === defaultProjectName) return true;
+  return allowList.includes(projectName);
+}
+
+/**
+ * 拒否時のメッセージ。許可済みの一覧をそのまま見せる — 隠しても攻撃者には効かず、
+ * 設定ミスを直す人が困るだけなので。
+ */
+export function projectNotAllowedMessage(
+  projectName: string,
+  defaultProjectName: string | undefined
+): string {
+  // 既定プロジェクトは暗黙に許可されるので、案内にも含めないと嘘になる
+  const permitted = [
+    ...(defaultProjectName ? [defaultProjectName] : []),
+    ...(getProjectAllowList() ?? []),
+  ];
+  const unique = permitted.filter((name, index) => permitted.indexOf(name) === index);
+  return `Project '${projectName}' is not allowed by COSENSE_PROJECT_ALLOW_LIST. Permitted projects: ${unique.join(', ')}`;
+}
+
+/**
+ * 許可されていなければエラーメッセージ、許可されていれば undefined を返す。
+ *
+ * 例外ではなく戻り値にしてあるのは、プロジェクト名を `try` の外で解決しているハンドラが
+ * あるため。投げるとそこだけ catch されない。呼び出し側は受け取った文字列を
+ * それぞれの `formatError` に載せる。
+ */
+export function checkProjectAllowed(
+  projectName: string,
+  defaultProjectName: string | undefined
+): string | undefined {
+  if (isProjectAllowed(projectName, defaultProjectName)) return undefined;
+  return projectNotAllowedMessage(projectName, defaultProjectName);
+}


### PR DESCRIPTION
Fixes #60

Issue #60 と[いただいたコメント](https://github.com/worldnine/scrapbox-cosense-mcp/issues/60#issuecomment-5472544227)の方針どおりに実装しました。フォーク固有の差分は入れていません。

## 仕様

- `COSENSE_PROJECT_ALLOW_LIST`（カンマ区切り）。未設定なら従来どおり無制限
- `COSENSE_PROJECT_NAME` は暗黙に許可リストへ含める
- 拒否時のエラーに許可済みプロジェクトの一覧を出す
- 照合は大文字小文字を区別する
- 各要素は前後の空白をトリムし、空要素は無視する

## 置き場所

ご提案どおり、共有ヘルパー（`src/utils/project.ts`）を各ハンドラがプロジェクト名の解決直後に呼ぶ形にしました。ディスパッチャ側には置いていません。

- `checkProjectAllowed` は例外ではなくメッセージ文字列を返します。`delete-lines` / `delete-page` / `edit-lines` / `rewrite-page` がプロジェクト名を `try` の外で解決している件は、これで catch の位置に依存しなくなります
- 環境変数は `isDeleteEnabled()` と同じく呼び出しごとに読みます
- `get-page-url` だけは `formatError` を使わない独自のエラー書式なので、同ファイルの `catch` に合わせました
- 判定は API 呼び出しより前に入るので、拒否時は Cosense へのリクエストが1本も出ません（テストで確認）

## 実装中に見つかった落とし穴（3つ目のコミット）

**暗黙に許可する既定プロジェクトを、ハンドラ引数の `defaultProjectName` から取ると CLI 経路だけ素通りします。** CLI は `--project=NAME` の値を第1引数としてもハンドラに渡すため、`projectName === defaultProjectName` が常に成立するためです。

```
COSENSE_PROJECT_NAME=allowed-default COSENSE_PROJECT_ALLOW_LIST=allowed-default \
  scrapbox-cosense-mcp url TestPage --project=forbidden-project
# → 弾かれずに exit 0 で URL を返していました
```

判定の基準を `process.env.COSENSE_PROJECT_NAME` に変えて塞いであります。許可リストと同じ環境変数から取るので、呼び出し側の渡し方で柵が消えることが無くなります。MCP 側は元々 `src/index.ts` が同じ環境変数からプロジェクト名を取っているため、挙動は変わりません。

経緯が分かるように、修正は別コミットにしてあります。

## テスト

- `src/__tests__/utils/project.test.ts` — ヘルパーの単体テスト（19件）
- `src/__tests__/handlers/project-allow-list.test.ts` — **全ハンドラを列挙**して、許可外プロジェクトで必ずエラーになること・API を呼ばないこと・許可リスト未設定なら何も変わらないことを見ています（56件）
  - ハンドラのファイル一覧と列挙が一致することも確認しているので、**新しいツールを足して判定を入れ忘れると落ちます**
  - ハンドラから判定を1つ消すと該当テストが落ちること、ハンドラを1つ足すと列挙のテストが落ちることを実際に確認しました
- `src/__tests__/cli-project-allow-list.test.ts` — CLI 経路の回帰テスト（ハンドラをモックせず `runCli` から通します）

合計 342 件パス、lint エラー 0、`npm run build` 通過です。

## 未着手・判断を仰ぎたい点

- **ドキュメントは触っていません。** README の環境変数一覧はそちらでやってくださるとのことでしたので、`CLAUDE.md` も揃えて書かれたほうが文体が揃うと思い、手を付けませんでした。こちらで足す形がよければ言ってください
- `COSENSE_PROJECT_ALLOW_LIST=",,,"` のように**設定はしたが実質空**の場合は、未設定と同じ無制限扱いになります。「空要素は無視する」の素直な帰結ですが、「設定したつもりで無制限」に倒れる解釈なので、拒否側に倒すべきであれば直します
- `delete_page` / `rewrite_page` では、許可リストの判定を `COSENSE_ENABLE_DELETE` のゲートより**前**に置いています。そのため削除が無効な環境でも、許可外プロジェクトを指定すると許可済みプロジェクト名の一覧が出ます。順序を入れ替えたほうがよければ直します
- `package.json` / `manifest.json` の version は触っていません
